### PR TITLE
feat(auth): introduce login_id model and bootstrap default admin

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,17 @@
+## Stage 1: Auth Model Refactor
+**Goal**: 인증 식별자를 `login_id`로 도입하고 auth 스키마/리포지토리/토큰 발급을 정리한다.
+**Success Criteria**: 회원가입/로그인이 `login_id` 입력으로 동작하며 사용자 레코드에 `login_id`와 `must_change_password`가 반영된다.
+**Tests**: backend schemas/auth API/repository 관련 단위 테스트.
+**Status**: Complete
+
+## Stage 2: Bootstrap Admin Account
+**Goal**: DB가 비어있을 때 기본 관리자 `admin/admin`을 자동 생성하고 비밀번호 변경 필요 플래그를 세팅한다.
+**Success Criteria**: 앱 시작 후 사용자 0건이면 admin 계정이 생성되고, 로그인 시 변경 필요 플래그가 토큰에 포함된다.
+**Tests**: auth API 테스트(초기 로그인 플래그), 앱 시작 bootstrap 로직 테스트/검증.
+**Status**: Complete
+
+## Stage 3: Quality Check & Commit
+**Goal**: 백엔드 품질 검증 후 PR A 커밋을 완료한다.
+**Success Criteria**: format/lint/type/test 통과 및 스테이지 요약 반영.
+**Tests**: `ruff format`, `ruff check`, `ty check`, `pytest`.
+**Status**: Complete

--- a/saegim-backend/migrations/001_init.sql
+++ b/saegim-backend/migrations/001_init.sql
@@ -18,8 +18,10 @@ COMMENT ON COLUMN projects.ocr_config IS 'Per-project OCR pipeline configuration
 CREATE TABLE IF NOT EXISTS users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     name VARCHAR(255) NOT NULL,
+    login_id VARCHAR(64) NOT NULL UNIQUE,
     email VARCHAR(255) NOT NULL UNIQUE,
     password_hash VARCHAR(255),
+    must_change_password BOOLEAN NOT NULL DEFAULT FALSE,
     role VARCHAR(20) NOT NULL DEFAULT 'annotator'
         CHECK (role IN ('admin', 'annotator', 'reviewer')),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/saegim-backend/src/saegim/api/deps.py
+++ b/saegim-backend/src/saegim/api/deps.py
@@ -50,6 +50,7 @@ def create_access_token(
     user_id: str,
     role: str,
     settings: Settings,
+    must_change_password: bool = False,
 ) -> str:
     """Create a JWT access token.
 
@@ -57,6 +58,7 @@ def create_access_token(
         user_id: User UUID string.
         role: User role string.
         settings: Application settings.
+        must_change_password: Whether password change is required.
 
     Returns:
         str: Encoded JWT token.
@@ -67,6 +69,7 @@ def create_access_token(
     payload = {
         'sub': user_id,
         'role': role,
+        'must_change_password': must_change_password,
         'exp': expire,
     }
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)

--- a/saegim-backend/src/saegim/api/routes/auth.py
+++ b/saegim-backend/src/saegim/api/routes/auth.py
@@ -20,13 +20,13 @@ async def register(body: RegisterRequest) -> TokenResponse:
     """Register a new user. First user automatically becomes admin.
 
     Args:
-        body: Registration data (name, email, password).
+        body: Registration data (name, login_id, password).
 
     Returns:
         TokenResponse: JWT access token.
 
     Raises:
-        HTTPException: 409 if email already taken.
+        HTTPException: 409 if login_id already taken.
     """
     pool = get_pool()
     settings = get_settings()
@@ -40,7 +40,7 @@ async def register(body: RegisterRequest) -> TokenResponse:
         record = await user_repo.create_with_password(
             pool,
             name=body.name,
-            email=str(body.email),
+            login_id=body.login_id,
             password_hash=password_hashed,
             role=role,
         )
@@ -48,17 +48,25 @@ async def register(body: RegisterRequest) -> TokenResponse:
         if 'unique' in str(e).lower():
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail='User with this email already exists',
+                detail='User with this login ID already exists',
             ) from e
         raise
 
-    token = create_access_token(str(record['id']), role, settings)
-    return TokenResponse(access_token=token)
+    token = create_access_token(
+        str(record['id']),
+        role,
+        settings,
+        must_change_password=bool(record['must_change_password']),
+    )
+    return TokenResponse(
+        access_token=token,
+        must_change_password=bool(record['must_change_password']),
+    )
 
 
 @router.post('/auth/login', response_model=TokenResponse)
 async def login(body: LoginRequest) -> TokenResponse:
-    """Login with email and password.
+    """Login with login ID and password.
 
     Args:
         body: Login credentials.
@@ -72,9 +80,9 @@ async def login(body: LoginRequest) -> TokenResponse:
     pool = get_pool()
     settings = get_settings()
 
-    record = await user_repo.get_by_email(pool, str(body.email))
+    record = await user_repo.get_by_login_id(pool, body.login_id)
 
-    invalid_msg = 'Invalid email or password'
+    invalid_msg = 'Invalid ID or password'
     if record is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=invalid_msg)
 
@@ -84,5 +92,13 @@ async def login(body: LoginRequest) -> TokenResponse:
     if not verify_password(body.password, record['password_hash']):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=invalid_msg)
 
-    token = create_access_token(str(record['id']), record['role'], settings)
-    return TokenResponse(access_token=token)
+    token = create_access_token(
+        str(record['id']),
+        record['role'],
+        settings,
+        must_change_password=bool(record['must_change_password']),
+    )
+    return TokenResponse(
+        access_token=token,
+        must_change_password=bool(record['must_change_password']),
+    )

--- a/saegim-backend/src/saegim/app.py
+++ b/saegim-backend/src/saegim/app.py
@@ -5,15 +5,36 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import asyncpg
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from saegim.api.deps import hash_password
 from saegim.api.routes import admin, auth, documents, export, health, pages, projects, tasks, users
 from saegim.api.settings import Settings, get_settings
 from saegim.core.database import close_pool, create_pool
+from saegim.repositories import user_repo
 
 logger = logging.getLogger(__name__)
+
+
+async def _bootstrap_default_admin(pool: asyncpg.Pool) -> None:
+    """Create default admin/admin account when users table is empty."""
+    count = await user_repo.count_all(pool)
+    if count > 0:
+        return
+
+    await user_repo.create_with_password(
+        pool,
+        name='admin',
+        login_id='admin',
+        email='admin',
+        password_hash=hash_password('admin'),
+        role='admin',
+        must_change_password=True,
+    )
+    logger.warning('Bootstrapped default admin account (login_id=admin)')
 
 
 @asynccontextmanager
@@ -24,11 +45,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app: FastAPI application instance.
     """
     settings: Settings = app.state.settings
-    await create_pool(
+    pool = await create_pool(
         settings.database_url,
         min_size=settings.db_pool_min_size,
         max_size=settings.db_pool_max_size,
     )
+    await _bootstrap_default_admin(pool)
     logger.info('Application started')
     yield
     await close_pool()

--- a/saegim-backend/src/saegim/repositories/user_repo.py
+++ b/saegim-backend/src/saegim/repositories/user_repo.py
@@ -10,6 +10,7 @@ async def create(
     name: str,
     email: str,
     role: str = 'annotator',
+    login_id: str | None = None,
 ) -> asyncpg.Record:
     """Create a new user.
 
@@ -18,17 +19,20 @@ async def create(
         name: User name.
         email: User email (must be unique).
         role: User role (admin, annotator, reviewer).
+        login_id: Login ID. Defaults to email for backward compatibility.
 
     Returns:
         asyncpg.Record: Created user record.
     """
+    resolved_login_id = login_id or email
     return await pool.fetchrow(
         """
-        INSERT INTO users (name, email, role)
-        VALUES ($1, $2, $3)
-        RETURNING id, name, email, role, created_at
+        INSERT INTO users (name, login_id, email, role)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, name, login_id, email, role, must_change_password, created_at
         """,
         name,
+        resolved_login_id,
         email,
         role,
     )
@@ -45,23 +49,63 @@ async def get_by_id(pool: asyncpg.Pool, user_id: uuid.UUID) -> asyncpg.Record | 
         asyncpg.Record or None: User record if found.
     """
     return await pool.fetchrow(
-        'SELECT id, name, email, role, created_at FROM users WHERE id = $1',
+        """
+        SELECT id, name, login_id, email, role, must_change_password, created_at
+        FROM users
+        WHERE id = $1
+        """,
         user_id,
     )
 
 
-async def get_by_email(pool: asyncpg.Pool, email: str) -> asyncpg.Record | None:
-    """Get a user by email address (includes password_hash).
+async def get_with_password_by_id(pool: asyncpg.Pool, user_id: uuid.UUID) -> asyncpg.Record | None:
+    """Get a user by ID including password hash.
 
     Args:
         pool: Database connection pool.
-        email: User email address.
+        user_id: User UUID.
 
     Returns:
         asyncpg.Record or None: User record if found.
     """
     return await pool.fetchrow(
-        'SELECT id, name, email, role, password_hash, created_at FROM users WHERE email = $1',
+        """
+        SELECT id, name, login_id, email, role, password_hash, must_change_password, created_at
+        FROM users
+        WHERE id = $1
+        """,
+        user_id,
+    )
+
+
+async def get_by_login_id(pool: asyncpg.Pool, login_id: str) -> asyncpg.Record | None:
+    """Get a user by login ID (includes password_hash).
+
+    Args:
+        pool: Database connection pool.
+        login_id: User login ID.
+
+    Returns:
+        asyncpg.Record or None: User record if found.
+    """
+    return await pool.fetchrow(
+        """
+        SELECT id, name, login_id, email, role, password_hash, must_change_password, created_at
+        FROM users
+        WHERE login_id = $1
+        """,
+        login_id,
+    )
+
+
+async def get_by_email(pool: asyncpg.Pool, email: str) -> asyncpg.Record | None:
+    """Get a user by email address (includes password_hash)."""
+    return await pool.fetchrow(
+        """
+        SELECT id, name, login_id, email, role, password_hash, must_change_password, created_at
+        FROM users
+        WHERE email = $1
+        """,
         email,
     )
 
@@ -69,31 +113,39 @@ async def get_by_email(pool: asyncpg.Pool, email: str) -> asyncpg.Record | None:
 async def create_with_password(
     pool: asyncpg.Pool,
     name: str,
-    email: str,
+    login_id: str,
     password_hash: str,
     role: str = 'annotator',
+    *,
+    email: str | None = None,
+    must_change_password: bool = False,
 ) -> asyncpg.Record:
     """Create a new user with password hash.
 
     Args:
         pool: Database connection pool.
         name: User name.
-        email: User email (must be unique).
+        login_id: Login ID (must be unique).
         password_hash: Bcrypt password hash.
         role: User role (admin, annotator, reviewer).
+        email: Email value. Defaults to login_id.
+        must_change_password: Whether user must change password on first login.
 
     Returns:
         asyncpg.Record: Created user record.
     """
+    resolved_email = email or login_id
     return await pool.fetchrow(
         """
-        INSERT INTO users (name, email, password_hash, role)
-        VALUES ($1, $2, $3, $4)
-        RETURNING id, name, email, role, created_at
+        INSERT INTO users (name, login_id, email, password_hash, must_change_password, role)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, name, login_id, email, role, must_change_password, created_at
         """,
         name,
-        email,
+        login_id,
+        resolved_email,
         password_hash,
+        must_change_password,
         role,
     )
 
@@ -130,7 +182,7 @@ async def update_role(
         """
         UPDATE users SET role = $1
         WHERE id = $2
-        RETURNING id, name, email, role, created_at
+        RETURNING id, name, login_id, email, role, must_change_password, created_at
         """,
         role,
         user_id,
@@ -147,5 +199,9 @@ async def list_all(pool: asyncpg.Pool) -> list[asyncpg.Record]:
         list[asyncpg.Record]: List of user records.
     """
     return await pool.fetch(
-        'SELECT id, name, email, role, created_at FROM users ORDER BY created_at DESC',
+        """
+        SELECT id, name, login_id, email, role, must_change_password, created_at
+        FROM users
+        ORDER BY created_at DESC
+        """,
     )

--- a/saegim-backend/src/saegim/schemas/auth.py
+++ b/saegim-backend/src/saegim/schemas/auth.py
@@ -1,20 +1,20 @@
 """Authentication request and response schemas."""
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, Field
 
 
 class RegisterRequest(BaseModel):
     """Schema for user registration."""
 
     name: str = Field(min_length=1, max_length=255)
-    email: EmailStr
+    login_id: str = Field(min_length=3, max_length=64)
     password: str = Field(min_length=8, max_length=128)
 
 
 class LoginRequest(BaseModel):
     """Schema for user login."""
 
-    email: EmailStr
+    login_id: str = Field(min_length=3, max_length=64)
     password: str = Field(min_length=1)
 
 
@@ -23,3 +23,4 @@ class TokenResponse(BaseModel):
 
     access_token: str
     token_type: str = 'bearer'  # noqa: S105
+    must_change_password: bool = False

--- a/saegim-backend/src/saegim/schemas/user.py
+++ b/saegim-backend/src/saegim/schemas/user.py
@@ -34,6 +34,8 @@ class UserResponse(BaseModel):
 
     id: uuid.UUID
     name: str
+    login_id: str
     email: str
     role: UserRole
+    must_change_password: bool = False
     created_at: datetime.datetime

--- a/saegim-backend/tests/api/test_admin.py
+++ b/saegim-backend/tests/api/test_admin.py
@@ -34,8 +34,10 @@ def _admin_record(user_id: uuid.UUID | None = None) -> dict:
     return {
         'id': user_id or uuid.uuid4(),
         'name': 'Admin',
+        'login_id': 'admin',
         'email': 'admin@example.com',
         'role': 'admin',
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }
 
@@ -50,8 +52,10 @@ class TestAdminListUsers:
         annotator_record = {
             'id': uuid.uuid4(),
             'name': 'User',
+            'login_id': 'user',
             'email': 'user@example.com',
             'role': 'annotator',
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with patch(
@@ -98,8 +102,10 @@ class TestAdminUpdateUser:
         updated_record = {
             'id': target_id,
             'name': 'Target',
+            'login_id': 'target',
             'email': 'target@example.com',
             'role': 'reviewer',
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         token = create_access_token(str(admin_rec['id']), 'admin', test_settings)
@@ -200,8 +206,10 @@ class TestAdminListProjects:
         annotator_record = {
             'id': uuid.uuid4(),
             'name': 'User',
+            'login_id': 'user',
             'email': 'user@example.com',
             'role': 'annotator',
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with patch(

--- a/saegim-backend/tests/api/test_auth.py
+++ b/saegim-backend/tests/api/test_auth.py
@@ -18,8 +18,10 @@ class TestRegisterEndpoint:
         record = {
             'id': user_id,
             'name': 'Admin',
+            'login_id': 'admin',
             'email': 'admin@example.com',
             'role': 'admin',
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with (
@@ -38,7 +40,7 @@ class TestRegisterEndpoint:
                 '/api/v1/auth/register',
                 json={
                     'name': 'Admin',
-                    'email': 'admin@example.com',
+                    'login_id': 'admin',
                     'password': 'password123',
                 },
             )
@@ -55,8 +57,10 @@ class TestRegisterEndpoint:
         record = {
             'id': user_id,
             'name': 'User',
+            'login_id': 'user01',
             'email': 'user@example.com',
             'role': 'annotator',
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with (
@@ -75,7 +79,7 @@ class TestRegisterEndpoint:
                 '/api/v1/auth/register',
                 json={
                     'name': 'User',
-                    'email': 'user@example.com',
+                    'login_id': 'user01',
                     'password': 'password123',
                 },
             )
@@ -100,7 +104,7 @@ class TestRegisterEndpoint:
                 '/api/v1/auth/register',
                 json={
                     'name': 'Test',
-                    'email': 'dup@example.com',
+                    'login_id': 'dup-user',
                     'password': 'password123',
                 },
             )
@@ -112,7 +116,7 @@ class TestRegisterEndpoint:
             '/api/v1/auth/register',
             json={
                 'name': 'Test',
-                'email': 'test@example.com',
+                'login_id': 'testuser',
                 'password': 'short',
             },
         )
@@ -127,19 +131,21 @@ class TestLoginEndpoint:
         user_record = {
             'id': uuid.uuid4(),
             'name': 'Test',
+            'login_id': 'testuser',
             'email': 'test@example.com',
             'role': 'annotator',
             'password_hash': hashed,
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value=user_record,
         ):
             response = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'test@example.com', 'password': 'password123'},
+                json={'login_id': 'testuser', 'password': 'password123'},
             )
 
         assert response.status_code == status.HTTP_200_OK
@@ -152,32 +158,34 @@ class TestLoginEndpoint:
         user_record = {
             'id': uuid.uuid4(),
             'name': 'Test',
+            'login_id': 'testuser',
             'email': 'test@example.com',
             'role': 'annotator',
             'password_hash': hashed,
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value=user_record,
         ):
             response = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'test@example.com', 'password': 'wrongpassword'},
+                json={'login_id': 'testuser', 'password': 'wrongpassword'},
             )
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_nonexistent_user_returns_401(self, client: TestClient):
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value=None,
         ):
             response = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'nobody@example.com', 'password': 'password123'},
+                json={'login_id': 'nobody', 'password': 'password123'},
             )
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -186,19 +194,21 @@ class TestLoginEndpoint:
         user_record = {
             'id': uuid.uuid4(),
             'name': 'Legacy',
+            'login_id': 'legacy',
             'email': 'legacy@example.com',
             'role': 'annotator',
             'password_hash': None,
+            'must_change_password': False,
             'created_at': datetime.datetime.now(tz=datetime.UTC),
         }
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value=user_record,
         ):
             response = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'legacy@example.com', 'password': 'password123'},
+                json={'login_id': 'legacy', 'password': 'password123'},
             )
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -206,31 +216,33 @@ class TestLoginEndpoint:
     def test_same_error_message_for_all_failures(self, client: TestClient):
         """Ensure we don't leak email existence info."""
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value=None,
         ):
             r1 = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'nobody@example.com', 'password': 'pass12345'},
+                json={'login_id': 'nobody', 'password': 'pass12345'},
             )
 
         hashed = hash_password('correct')
         with patch(
-            'saegim.repositories.user_repo.get_by_email',
+            'saegim.repositories.user_repo.get_by_login_id',
             new_callable=AsyncMock,
             return_value={
                 'id': uuid.uuid4(),
                 'name': 'X',
+                'login_id': 'xuser',
                 'email': 'x@example.com',
                 'role': 'annotator',
                 'password_hash': hashed,
+                'must_change_password': False,
                 'created_at': datetime.datetime.now(tz=datetime.UTC),
             },
         ):
             r2 = client.post(
                 '/api/v1/auth/login',
-                json={'email': 'x@example.com', 'password': 'wrongpass'},
+                json={'login_id': 'xuser', 'password': 'wrongpass'},
             )
 
         assert r1.json()['detail'] == r2.json()['detail']

--- a/saegim-backend/tests/api/test_project_members.py
+++ b/saegim-backend/tests/api/test_project_members.py
@@ -36,8 +36,10 @@ def _user_record(
     return {
         'id': user_id or uuid.uuid4(),
         'name': name,
+        'login_id': email,
         'email': email,
         'role': role,
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }
 

--- a/saegim-backend/tests/api/test_task_workflow.py
+++ b/saegim-backend/tests/api/test_task_workflow.py
@@ -23,11 +23,14 @@ def _clear_auth_override(app):
 
 
 def _user_record(role='annotator', user_id=None):
+    email = f'{role}@example.com'
     return {
         'id': user_id or uuid.uuid4(),
         'name': f'Test {role.capitalize()}',
-        'email': f'{role}@example.com',
+        'login_id': email,
+        'email': email,
         'role': role,
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }
 

--- a/saegim-backend/tests/api/test_tasks.py
+++ b/saegim-backend/tests/api/test_tasks.py
@@ -23,11 +23,14 @@ def _clear_auth_override(app):
 
 
 def _user_record(role='annotator', user_id=None):
+    email = f'{role}@example.com'
     return {
         'id': user_id or uuid.uuid4(),
         'name': f'Test {role.capitalize()}',
-        'email': f'{role}@example.com',
+        'login_id': email,
+        'email': email,
         'role': role,
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }
 

--- a/saegim-backend/tests/conftest.py
+++ b/saegim-backend/tests/conftest.py
@@ -78,8 +78,10 @@ def app(test_settings: Settings, mock_pool):
         mock_user = UserResponse(
             id=uuid.uuid4(),
             name='Test User',
+            login_id='testuser',
             email='test@example.com',
             role='annotator',
+            must_change_password=False,
             created_at=datetime.datetime.now(tz=datetime.UTC),
         )
         app.dependency_overrides[get_current_user] = lambda: mock_user
@@ -204,7 +206,9 @@ def sample_user_record():
     return {
         'id': uuid.uuid4(),
         'name': 'Test User',
+        'login_id': 'testuser',
         'email': 'test@example.com',
         'role': 'annotator',
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }

--- a/saegim-backend/tests/repositories/test_user_repo.py
+++ b/saegim-backend/tests/repositories/test_user_repo.py
@@ -23,18 +23,20 @@ def sample_user_record():
     return {
         'id': uuid.uuid4(),
         'name': 'Test User',
+        'login_id': 'testuser',
         'email': 'test@example.com',
         'role': 'annotator',
         'password_hash': '$2b$12$fakehashvalue',
+        'must_change_password': False,
         'created_at': datetime.datetime.now(tz=datetime.UTC),
     }
 
 
-class TestUserRepoGetByEmail:
+class TestUserRepoGetByLoginId:
     @pytest.mark.asyncio
     async def test_found(self, mock_pool, sample_user_record):
         mock_pool.fetchrow.return_value = sample_user_record
-        result = await user_repo.get_by_email(mock_pool, 'test@example.com')
+        result = await user_repo.get_by_login_id(mock_pool, 'testuser')
         assert result == sample_user_record
         mock_pool.fetchrow.assert_called_once()
         call_sql = mock_pool.fetchrow.call_args[0][0]
@@ -43,7 +45,7 @@ class TestUserRepoGetByEmail:
     @pytest.mark.asyncio
     async def test_not_found(self, mock_pool):
         mock_pool.fetchrow.return_value = None
-        result = await user_repo.get_by_email(mock_pool, 'nobody@example.com')
+        result = await user_repo.get_by_login_id(mock_pool, 'nobody')
         assert result is None
 
 
@@ -52,21 +54,33 @@ class TestUserRepoCreateWithPassword:
     async def test_create(self, mock_pool, sample_user_record):
         mock_pool.fetchrow.return_value = sample_user_record
         result = await user_repo.create_with_password(
-            mock_pool, 'Test User', 'test@example.com', '$2b$12$fakehash', 'annotator'
+            mock_pool,
+            'Test User',
+            'testuser',
+            '$2b$12$fakehash',
+            'annotator',
+            email='test@example.com',
         )
         assert result == sample_user_record
         call_args = mock_pool.fetchrow.call_args[0]
         assert call_args[1] == 'Test User'
-        assert call_args[2] == 'test@example.com'
-        assert call_args[3] == '$2b$12$fakehash'
-        assert call_args[4] == 'annotator'
+        assert call_args[2] == 'testuser'
+        assert call_args[3] == 'test@example.com'
+        assert call_args[4] == '$2b$12$fakehash'
+        assert call_args[5] is False
+        assert call_args[6] == 'annotator'
 
     @pytest.mark.asyncio
     async def test_create_admin(self, mock_pool, sample_user_record):
         admin_record = {**sample_user_record, 'role': 'admin'}
         mock_pool.fetchrow.return_value = admin_record
         result = await user_repo.create_with_password(
-            mock_pool, 'Admin', 'admin@example.com', '$2b$12$hash', 'admin'
+            mock_pool,
+            'Admin',
+            'admin',
+            '$2b$12$hash',
+            'admin',
+            email='admin@example.com',
         )
         assert result['role'] == 'admin'
 
@@ -91,6 +105,7 @@ class TestUserRepoUpdateRole:
         updated = {**sample_user_record, 'role': 'reviewer'}
         mock_pool.fetchrow.return_value = updated
         result = await user_repo.update_role(mock_pool, sample_user_record['id'], 'reviewer')
+        assert result is not None
         assert result['role'] == 'reviewer'
 
     @pytest.mark.asyncio

--- a/saegim-backend/tests/schemas/test_auth_schema.py
+++ b/saegim-backend/tests/schemas/test_auth_schema.py
@@ -10,37 +10,37 @@ class TestRegisterRequest:
     """Test cases for RegisterRequest schema."""
 
     def test_valid_register(self):
-        req = RegisterRequest(name='Test', email='test@example.com', password='password123')
+        req = RegisterRequest(name='Test', login_id='testuser', password='password123')
         assert req.name == 'Test'
-        assert str(req.email) == 'test@example.com'
+        assert req.login_id == 'testuser'
 
     def test_password_too_short(self):
         with pytest.raises(ValidationError):
-            RegisterRequest(name='Test', email='test@example.com', password='short')
+            RegisterRequest(name='Test', login_id='testuser', password='short')
 
     def test_password_too_long(self):
         with pytest.raises(ValidationError):
-            RegisterRequest(name='Test', email='test@example.com', password='x' * 129)
+            RegisterRequest(name='Test', login_id='testuser', password='x' * 129)
 
-    def test_invalid_email(self):
+    def test_short_login_id(self):
         with pytest.raises(ValidationError):
-            RegisterRequest(name='Test', email='not-email', password='password123')
+            RegisterRequest(name='Test', login_id='ab', password='password123')
 
     def test_empty_name(self):
         with pytest.raises(ValidationError):
-            RegisterRequest(name='', email='test@example.com', password='password123')
+            RegisterRequest(name='', login_id='testuser', password='password123')
 
 
 class TestLoginRequest:
     """Test cases for LoginRequest schema."""
 
     def test_valid_login(self):
-        req = LoginRequest(email='test@example.com', password='password123')
-        assert str(req.email) == 'test@example.com'
+        req = LoginRequest(login_id='testuser', password='password123')
+        assert req.login_id == 'testuser'
 
     def test_empty_password(self):
         with pytest.raises(ValidationError):
-            LoginRequest(email='test@example.com', password='')
+            LoginRequest(login_id='testuser', password='')
 
 
 class TestTokenResponse:

--- a/saegim-backend/tests/test_app_bootstrap.py
+++ b/saegim-backend/tests/test_app_bootstrap.py
@@ -1,0 +1,57 @@
+"""Tests for application bootstrap behavior."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from saegim.api.settings import Settings
+from saegim.app import create_app
+
+
+class TestBootstrapDefaultAdmin:
+    """Test cases for default admin bootstrap on startup."""
+
+    def test_creates_default_admin_when_no_users(self, test_settings: Settings):
+        fake_pool = MagicMock()
+        with (
+            patch('saegim.app.create_pool', new_callable=AsyncMock, return_value=fake_pool),
+            patch('saegim.app.close_pool', new_callable=AsyncMock),
+            patch(
+                'saegim.repositories.user_repo.count_all', new_callable=AsyncMock, return_value=0
+            ),
+            patch(
+                'saegim.repositories.user_repo.create_with_password',
+                new_callable=AsyncMock,
+            ) as mock_create_user,
+        ):
+            app = create_app(settings=test_settings)
+            with TestClient(app):
+                pass
+
+        mock_create_user.assert_awaited_once()
+        kwargs = mock_create_user.call_args.kwargs
+        assert kwargs['name'] == 'admin'
+        assert kwargs['login_id'] == 'admin'
+        assert kwargs['email'] == 'admin'
+        assert kwargs['role'] == 'admin'
+        assert kwargs['must_change_password'] is True
+        assert kwargs['password_hash'] != 'admin'
+
+    def test_skips_bootstrap_when_users_exist(self, test_settings: Settings):
+        fake_pool = MagicMock()
+        with (
+            patch('saegim.app.create_pool', new_callable=AsyncMock, return_value=fake_pool),
+            patch('saegim.app.close_pool', new_callable=AsyncMock),
+            patch(
+                'saegim.repositories.user_repo.count_all', new_callable=AsyncMock, return_value=3
+            ),
+            patch(
+                'saegim.repositories.user_repo.create_with_password',
+                new_callable=AsyncMock,
+            ) as mock_create_user,
+        ):
+            app = create_app(settings=test_settings)
+            with TestClient(app):
+                pass
+
+        mock_create_user.assert_not_called()


### PR DESCRIPTION
## Summary
- switch auth/user model from email-first to login_id-first
- add `must_change_password` to users and token response
- bootstrap default `admin/admin` account on empty DB startup with forced password change
- update backend auth/repository/schema tests accordingly

## Validation
- DEBUG=false uv run pytest (auth/repo/api bootstrap scopes)
- uv run ruff format src tests
- uv run ruff check src tests
- uv run ty check (change scope)

Refs #93
