### PR TITLE
feat(auth): add credential APIs for ID check and update

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,17 +1,17 @@
-## Stage 1: Auth Model Refactor
-**Goal**: 인증 식별자를 `login_id`로 도입하고 auth 스키마/리포지토리/토큰 발급을 정리한다.
-**Success Criteria**: 회원가입/로그인이 `login_id` 입력으로 동작하며 사용자 레코드에 `login_id`와 `must_change_password`가 반영된다.
-**Tests**: backend schemas/auth API/repository 관련 단위 테스트.
+## Stage 1: Login ID Availability API
+**Goal**: 회원가입/계정변경에서 재사용 가능한 ID 중복확인 API를 제공한다.
+**Success Criteria**: `GET /api/v1/auth/check-login-id`가 사용 가능 여부를 안정적으로 반환한다.
+**Tests**: auth API 테스트(available/unavailable).
 **Status**: Complete
 
-## Stage 2: Bootstrap Admin Account
-**Goal**: DB가 비어있을 때 기본 관리자 `admin/admin`을 자동 생성하고 비밀번호 변경 필요 플래그를 세팅한다.
-**Success Criteria**: 앱 시작 후 사용자 0건이면 admin 계정이 생성되고, 로그인 시 변경 필요 플래그가 토큰에 포함된다.
-**Tests**: auth API 테스트(초기 로그인 플래그), 앱 시작 bootstrap 로직 테스트/검증.
+## Stage 2: Credential Update API (ID/Password/Email)
+**Goal**: 로그인 유저가 본인 `login_id`, `password`, `email`을 변경할 수 있게 한다.
+**Success Criteria**: `PATCH /api/v1/auth/me/credentials`에서 현재 비밀번호 검증, 중복 검사, 토큰 재발급, must_change_password 갱신이 동작한다.
+**Tests**: auth API 테스트(성공/현재비밀번호오류/중복 ID/중복 이메일), schema/repository 테스트.
 **Status**: Complete
 
 ## Stage 3: Quality Check & Commit
-**Goal**: 백엔드 품질 검증 후 PR A 커밋을 완료한다.
-**Success Criteria**: format/lint/type/test 통과 및 스테이지 요약 반영.
-**Tests**: `ruff format`, `ruff check`, `ty check`, `pytest`.
+**Goal**: 백엔드 품질 검증 후 PR B 커밋을 완료한다.
+**Success Criteria**: format/lint/type/test 통과.
+**Tests**: `ruff format`, `ruff check`, `ty check(변경 범위)`, `pytest(변경 범위)`.
 **Status**: Complete

--- a/saegim-backend/src/saegim/api/routes/auth.py
+++ b/saegim-backend/src/saegim/api/routes/auth.py
@@ -2,17 +2,34 @@
 
 import logging
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from saegim.api.deps import create_access_token, hash_password, verify_password
+from saegim.api.deps import create_access_token, get_current_user, hash_password, verify_password
 from saegim.api.settings import get_settings
 from saegim.core.database import get_pool
 from saegim.repositories import user_repo
-from saegim.schemas.auth import LoginRequest, RegisterRequest, TokenResponse
+from saegim.schemas.auth import (
+    CredentialUpdateRequest,
+    LoginIdCheckResponse,
+    LoginRequest,
+    RegisterRequest,
+    TokenResponse,
+)
+from saegim.schemas.user import UserResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get('/auth/check-login-id', response_model=LoginIdCheckResponse)
+async def check_login_id(
+    login_id: str = Query(min_length=3, max_length=64),
+) -> LoginIdCheckResponse:
+    """Check whether a login ID is available."""
+    pool = get_pool()
+    available = not await user_repo.is_login_id_taken(pool, login_id)
+    return LoginIdCheckResponse(login_id=login_id, available=available)
 
 
 @router.post('/auth/register', response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
@@ -101,4 +118,66 @@ async def login(body: LoginRequest) -> TokenResponse:
     return TokenResponse(
         access_token=token,
         must_change_password=bool(record['must_change_password']),
+    )
+
+
+@router.patch('/auth/me/credentials', response_model=TokenResponse)
+async def update_my_credentials(
+    body: CredentialUpdateRequest,
+    current_user: UserResponse = Depends(get_current_user),  # noqa: B008
+) -> TokenResponse:
+    """Update current user's login_id/email/password."""
+    pool = get_pool()
+    settings = get_settings()
+
+    record = await user_repo.get_with_password_by_id(pool, current_user.id)
+    invalid_msg = 'Invalid current password'
+    if record is None or record['password_hash'] is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=invalid_msg)
+    if not verify_password(body.current_password, record['password_hash']):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=invalid_msg)
+
+    target_login_id = body.login_id if body.login_id is not None else record['login_id']
+    target_email = str(body.email) if body.email is not None else record['email']
+
+    if await user_repo.is_login_id_taken(pool, target_login_id, exclude_user_id=current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='User with this login ID already exists',
+        )
+    if await user_repo.is_email_taken(pool, target_email, exclude_user_id=current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='User with this email already exists',
+        )
+
+    password_hash = (
+        hash_password(body.new_password)
+        if body.new_password is not None
+        else record['password_hash']
+    )
+    must_change_password = (
+        False if body.new_password is not None else record['must_change_password']
+    )
+
+    updated = await user_repo.update_credentials(
+        pool,
+        current_user.id,
+        login_id=target_login_id,
+        email=target_email,
+        password_hash=password_hash,
+        must_change_password=must_change_password,
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='User not found')
+
+    token = create_access_token(
+        str(updated['id']),
+        updated['role'],
+        settings,
+        must_change_password=bool(updated['must_change_password']),
+    )
+    return TokenResponse(
+        access_token=token,
+        must_change_password=bool(updated['must_change_password']),
     )

--- a/saegim-backend/src/saegim/repositories/user_repo.py
+++ b/saegim-backend/src/saegim/repositories/user_repo.py
@@ -98,6 +98,33 @@ async def get_by_login_id(pool: asyncpg.Pool, login_id: str) -> asyncpg.Record |
     )
 
 
+async def is_login_id_taken(
+    pool: asyncpg.Pool,
+    login_id: str,
+    *,
+    exclude_user_id: uuid.UUID | None = None,
+) -> bool:
+    """Check whether login_id is already used by another user.
+
+    Args:
+        pool: Database connection pool.
+        login_id: Login ID to check.
+        exclude_user_id: Optional user ID to ignore (for self-update).
+
+    Returns:
+        bool: True when the login ID is already taken.
+    """
+    if exclude_user_id is None:
+        row = await pool.fetchrow('SELECT 1 FROM users WHERE login_id = $1 LIMIT 1', login_id)
+    else:
+        row = await pool.fetchrow(
+            'SELECT 1 FROM users WHERE login_id = $1 AND id != $2 LIMIT 1',
+            login_id,
+            exclude_user_id,
+        )
+    return row is not None
+
+
 async def get_by_email(pool: asyncpg.Pool, email: str) -> asyncpg.Record | None:
     """Get a user by email address (includes password_hash)."""
     return await pool.fetchrow(
@@ -108,6 +135,33 @@ async def get_by_email(pool: asyncpg.Pool, email: str) -> asyncpg.Record | None:
         """,
         email,
     )
+
+
+async def is_email_taken(
+    pool: asyncpg.Pool,
+    email: str,
+    *,
+    exclude_user_id: uuid.UUID | None = None,
+) -> bool:
+    """Check whether email is already used by another user.
+
+    Args:
+        pool: Database connection pool.
+        email: Email to check.
+        exclude_user_id: Optional user ID to ignore (for self-update).
+
+    Returns:
+        bool: True when the email is already taken.
+    """
+    if exclude_user_id is None:
+        row = await pool.fetchrow('SELECT 1 FROM users WHERE email = $1 LIMIT 1', email)
+    else:
+        row = await pool.fetchrow(
+            'SELECT 1 FROM users WHERE email = $1 AND id != $2 LIMIT 1',
+            email,
+            exclude_user_id,
+        )
+    return row is not None
 
 
 async def create_with_password(
@@ -147,6 +201,46 @@ async def create_with_password(
         password_hash,
         must_change_password,
         role,
+    )
+
+
+async def update_credentials(
+    pool: asyncpg.Pool,
+    user_id: uuid.UUID,
+    *,
+    login_id: str,
+    email: str,
+    password_hash: str,
+    must_change_password: bool,
+) -> asyncpg.Record | None:
+    """Update a user's credentials.
+
+    Args:
+        pool: Database connection pool.
+        user_id: User UUID.
+        login_id: New login ID.
+        email: New email value.
+        password_hash: New or existing password hash.
+        must_change_password: New must_change_password flag.
+
+    Returns:
+        asyncpg.Record or None: Updated user record, or None if not found.
+    """
+    return await pool.fetchrow(
+        """
+        UPDATE users
+        SET login_id = $1,
+            email = $2,
+            password_hash = $3,
+            must_change_password = $4
+        WHERE id = $5
+        RETURNING id, name, login_id, email, role, must_change_password, created_at
+        """,
+        login_id,
+        email,
+        password_hash,
+        must_change_password,
+        user_id,
     )
 
 

--- a/saegim-backend/src/saegim/schemas/auth.py
+++ b/saegim-backend/src/saegim/schemas/auth.py
@@ -1,6 +1,6 @@
 """Authentication request and response schemas."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field, model_validator
 
 
 class RegisterRequest(BaseModel):
@@ -24,3 +24,27 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = 'bearer'  # noqa: S105
     must_change_password: bool = False
+
+
+class LoginIdCheckResponse(BaseModel):
+    """Schema for login ID availability checks."""
+
+    login_id: str
+    available: bool
+
+
+class CredentialUpdateRequest(BaseModel):
+    """Schema for updating login credentials."""
+
+    current_password: str = Field(min_length=1, max_length=128)
+    login_id: str | None = Field(default=None, min_length=3, max_length=64)
+    email: EmailStr | None = None
+    new_password: str | None = Field(default=None, min_length=8, max_length=128)
+
+    @model_validator(mode='after')
+    def validate_has_update_target(self) -> 'CredentialUpdateRequest':
+        """Ensure at least one credential field is provided."""
+        if self.login_id is None and self.email is None and self.new_password is None:
+            msg = 'At least one of login_id, email, or new_password must be provided'
+            raise ValueError(msg)
+        return self

--- a/saegim-backend/tests/api/test_auth.py
+++ b/saegim-backend/tests/api/test_auth.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from saegim.api.deps import hash_password
+from saegim.api.deps import create_access_token, hash_password
 
 
 class TestRegisterEndpoint:
@@ -246,3 +246,217 @@ class TestLoginEndpoint:
             )
 
         assert r1.json()['detail'] == r2.json()['detail']
+
+    def test_login_returns_must_change_password_flag(self, client: TestClient):
+        hashed = hash_password('password123')
+        user_record = {
+            'id': uuid.uuid4(),
+            'name': 'Admin',
+            'login_id': 'admin',
+            'email': 'admin',
+            'role': 'admin',
+            'password_hash': hashed,
+            'must_change_password': True,
+            'created_at': datetime.datetime.now(tz=datetime.UTC),
+        }
+        with patch(
+            'saegim.repositories.user_repo.get_by_login_id',
+            new_callable=AsyncMock,
+            return_value=user_record,
+        ):
+            response = client.post(
+                '/api/v1/auth/login',
+                json={'login_id': 'admin', 'password': 'password123'},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['must_change_password'] is True
+
+
+class TestLoginIdCheckEndpoint:
+    """Test cases for GET /auth/check-login-id."""
+
+    def test_available(self, client: TestClient):
+        with patch(
+            'saegim.repositories.user_repo.is_login_id_taken',
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            response = client.get('/api/v1/auth/check-login-id?login_id=newuser')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {'login_id': 'newuser', 'available': True}
+
+    def test_unavailable(self, client: TestClient):
+        with patch(
+            'saegim.repositories.user_repo.is_login_id_taken',
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            response = client.get('/api/v1/auth/check-login-id?login_id=taken')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {'login_id': 'taken', 'available': False}
+
+
+class TestUpdateMyCredentialsEndpoint:
+    """Test cases for PATCH /auth/me/credentials."""
+
+    def test_update_login_id_email_and_password(self, client: TestClient, test_settings):
+        user_id = uuid.uuid4()
+        token = create_access_token(str(user_id), 'annotator', test_settings)
+        current_hash = hash_password('current-password')
+        current_record = {
+            'id': user_id,
+            'name': 'User',
+            'login_id': 'oldid',
+            'email': 'old@example.com',
+            'role': 'annotator',
+            'password_hash': current_hash,
+            'must_change_password': True,
+            'created_at': datetime.datetime.now(tz=datetime.UTC),
+        }
+        updated_record = {
+            **current_record,
+            'login_id': 'newid',
+            'email': 'new@example.com',
+            'must_change_password': False,
+        }
+
+        with (
+            patch(
+                'saegim.repositories.user_repo.get_with_password_by_id',
+                new_callable=AsyncMock,
+                return_value=current_record,
+            ),
+            patch(
+                'saegim.repositories.user_repo.is_login_id_taken',
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                'saegim.repositories.user_repo.is_email_taken',
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                'saegim.repositories.user_repo.update_credentials',
+                new_callable=AsyncMock,
+                return_value=updated_record,
+            ) as mock_update,
+        ):
+            response = client.patch(
+                '/api/v1/auth/me/credentials',
+                headers={'Authorization': f'Bearer {token}'},
+                json={
+                    'current_password': 'current-password',
+                    'login_id': 'newid',
+                    'email': 'new@example.com',
+                    'new_password': 'new-password123',
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['must_change_password'] is False
+        assert 'access_token' in data
+        assert mock_update.call_args.kwargs['login_id'] == 'newid'
+        assert mock_update.call_args.kwargs['email'] == 'new@example.com'
+        assert mock_update.call_args.kwargs['password_hash'] != current_hash
+
+    def test_invalid_current_password_returns_401(self, client: TestClient, test_settings):
+        user_id = uuid.uuid4()
+        token = create_access_token(str(user_id), 'annotator', test_settings)
+        current_record = {
+            'id': user_id,
+            'name': 'User',
+            'login_id': 'userid',
+            'email': 'user@example.com',
+            'role': 'annotator',
+            'password_hash': hash_password('correct-password'),
+            'must_change_password': False,
+            'created_at': datetime.datetime.now(tz=datetime.UTC),
+        }
+        with patch(
+            'saegim.repositories.user_repo.get_with_password_by_id',
+            new_callable=AsyncMock,
+            return_value=current_record,
+        ):
+            response = client.patch(
+                '/api/v1/auth/me/credentials',
+                headers={'Authorization': f'Bearer {token}'},
+                json={'current_password': 'wrong-password', 'login_id': 'newid'},
+            )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_duplicate_login_id_returns_409(self, client: TestClient, test_settings):
+        user_id = uuid.uuid4()
+        token = create_access_token(str(user_id), 'annotator', test_settings)
+        current_record = {
+            'id': user_id,
+            'name': 'User',
+            'login_id': 'userid',
+            'email': 'user@example.com',
+            'role': 'annotator',
+            'password_hash': hash_password('current-password'),
+            'must_change_password': False,
+            'created_at': datetime.datetime.now(tz=datetime.UTC),
+        }
+        with (
+            patch(
+                'saegim.repositories.user_repo.get_with_password_by_id',
+                new_callable=AsyncMock,
+                return_value=current_record,
+            ),
+            patch(
+                'saegim.repositories.user_repo.is_login_id_taken',
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            response = client.patch(
+                '/api/v1/auth/me/credentials',
+                headers={'Authorization': f'Bearer {token}'},
+                json={'current_password': 'current-password', 'login_id': 'taken'},
+            )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_duplicate_email_returns_409(self, client: TestClient, test_settings):
+        user_id = uuid.uuid4()
+        token = create_access_token(str(user_id), 'annotator', test_settings)
+        current_record = {
+            'id': user_id,
+            'name': 'User',
+            'login_id': 'userid',
+            'email': 'user@example.com',
+            'role': 'annotator',
+            'password_hash': hash_password('current-password'),
+            'must_change_password': False,
+            'created_at': datetime.datetime.now(tz=datetime.UTC),
+        }
+        with (
+            patch(
+                'saegim.repositories.user_repo.get_with_password_by_id',
+                new_callable=AsyncMock,
+                return_value=current_record,
+            ),
+            patch(
+                'saegim.repositories.user_repo.is_login_id_taken',
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                'saegim.repositories.user_repo.is_email_taken',
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            response = client.patch(
+                '/api/v1/auth/me/credentials',
+                headers={'Authorization': f'Bearer {token}'},
+                json={'current_password': 'current-password', 'email': 'taken@example.com'},
+            )
+
+        assert response.status_code == status.HTTP_409_CONFLICT

--- a/saegim-backend/tests/repositories/test_user_repo.py
+++ b/saegim-backend/tests/repositories/test_user_repo.py
@@ -113,3 +113,64 @@ class TestUserRepoUpdateRole:
         mock_pool.fetchrow.return_value = None
         result = await user_repo.update_role(mock_pool, uuid.uuid4(), 'admin')
         assert result is None
+
+
+class TestUserRepoAvailabilityChecks:
+    @pytest.mark.asyncio
+    async def test_login_id_taken(self, mock_pool):
+        mock_pool.fetchrow.return_value = {'?column?': 1}
+        taken = await user_repo.is_login_id_taken(mock_pool, 'taken-id')
+        assert taken is True
+
+    @pytest.mark.asyncio
+    async def test_login_id_available(self, mock_pool):
+        mock_pool.fetchrow.return_value = None
+        taken = await user_repo.is_login_id_taken(mock_pool, 'new-id')
+        assert taken is False
+
+    @pytest.mark.asyncio
+    async def test_email_taken(self, mock_pool):
+        mock_pool.fetchrow.return_value = {'?column?': 1}
+        taken = await user_repo.is_email_taken(mock_pool, 'taken@example.com')
+        assert taken is True
+
+    @pytest.mark.asyncio
+    async def test_email_available(self, mock_pool):
+        mock_pool.fetchrow.return_value = None
+        taken = await user_repo.is_email_taken(mock_pool, 'new@example.com')
+        assert taken is False
+
+
+class TestUserRepoUpdateCredentials:
+    @pytest.mark.asyncio
+    async def test_update_credentials_success(self, mock_pool, sample_user_record):
+        updated = {**sample_user_record, 'login_id': 'newid', 'email': 'new@example.com'}
+        mock_pool.fetchrow.return_value = updated
+
+        result = await user_repo.update_credentials(
+            mock_pool,
+            sample_user_record['id'],
+            login_id='newid',
+            email='new@example.com',
+            password_hash='$2b$12$newhash',
+            must_change_password=False,
+        )
+
+        assert result is not None
+        assert result['login_id'] == 'newid'
+        assert result['email'] == 'new@example.com'
+
+    @pytest.mark.asyncio
+    async def test_update_credentials_not_found(self, mock_pool):
+        mock_pool.fetchrow.return_value = None
+
+        result = await user_repo.update_credentials(
+            mock_pool,
+            uuid.uuid4(),
+            login_id='newid',
+            email='new@example.com',
+            password_hash='$2b$12$newhash',
+            must_change_password=False,
+        )
+
+        assert result is None

--- a/saegim-backend/tests/schemas/test_auth_schema.py
+++ b/saegim-backend/tests/schemas/test_auth_schema.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import ValidationError
 
-from saegim.schemas.auth import LoginRequest, RegisterRequest, TokenResponse
+from saegim.schemas.auth import (
+    CredentialUpdateRequest,
+    LoginIdCheckResponse,
+    LoginRequest,
+    RegisterRequest,
+    TokenResponse,
+)
 
 
 class TestRegisterRequest:
@@ -54,3 +60,36 @@ class TestTokenResponse:
     def test_custom_token_type(self):
         token = TokenResponse(access_token='abc', token_type='mac')
         assert token.token_type == 'mac'
+
+
+class TestLoginIdCheckResponse:
+    """Test cases for LoginIdCheckResponse schema."""
+
+    def test_valid_response(self):
+        payload = LoginIdCheckResponse(login_id='testuser', available=True)
+        assert payload.login_id == 'testuser'
+        assert payload.available is True
+
+
+class TestCredentialUpdateRequest:
+    """Test cases for CredentialUpdateRequest schema."""
+
+    def test_valid_with_login_id(self):
+        req = CredentialUpdateRequest(current_password='oldpassword', login_id='newid')
+        assert req.login_id == 'newid'
+
+    def test_valid_with_email(self):
+        req = CredentialUpdateRequest(current_password='oldpassword', email='new@example.com')
+        assert str(req.email) == 'new@example.com'
+
+    def test_valid_with_new_password(self):
+        req = CredentialUpdateRequest(current_password='oldpassword', new_password='newpassword123')
+        assert req.new_password == 'newpassword123'
+
+    def test_requires_at_least_one_target_field(self):
+        with pytest.raises(ValidationError):
+            CredentialUpdateRequest(current_password='oldpassword')
+
+    def test_invalid_email(self):
+        with pytest.raises(ValidationError):
+            CredentialUpdateRequest(current_password='oldpassword', email='invalid')


### PR DESCRIPTION
## Summary
- add `GET /api/v1/auth/check-login-id` for login ID availability checks
- add `PATCH /api/v1/auth/me/credentials` to update login ID, email, and password
- keep current-password verification and duplicate checks for both login_id and email
- issue new token after credential update and clear `must_change_password` on password change
- extend schema/repository/api tests

## Validation
- DEBUG=false uv run pytest tests/schemas/test_auth_schema.py tests/repositories/test_user_repo.py tests/api/test_auth.py
- uv run ruff format src tests
- uv run ruff check src tests
- uv run ty check (change scope)

Refs #93
