### PR TITLE
fix: guard against bun test running Bun native runner instead of Vitest

### DIFF
--- a/saegim-frontend/bunfig.toml
+++ b/saegim-frontend/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/bun-test-guard.ts"]

--- a/saegim-frontend/tests/bun-test-guard.ts
+++ b/saegim-frontend/tests/bun-test-guard.ts
@@ -1,0 +1,6 @@
+throw new Error(
+  '\n\n' +
+    '⚠ Do not use "bun test" — it runs Bun\'s built-in test runner,\n' +
+    'which cannot compile Svelte 5 runes ($state, $derived).\n\n' +
+    'Use "bun run test" instead (runs vitest).\n',
+)


### PR DESCRIPTION
## Summary
- `bun test`가 Vitest 대신 Bun 내장 테스트러너를 실행하여 Svelte 5 rune(`$state`, `$derived`) 컴파일 실패로 69개 테스트가 깨지는 문제 해결
- `bunfig.toml`의 `[test].preload`로 가드 스크립트를 등록하여 `bun test` 실행 시 `bun run test`(vitest) 사용을 안내하는 에러 메시지 출력

## Test plan
- [x] `bun test` 실행 시 가드 에러 메시지 출력 확인
- [x] `bun run test` 실행 시 22개 파일 226개 테스트 전부 통과 확인
- [x] oxlint 0 에러
- [x] svelte-check 0 에러

Closes #99