### PR TITLE
docs: continue README and UI i18n cleanup

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -14,4 +14,4 @@
 **Goal**: Improve MkDocs navigation coverage and English nav labels for translated documentation.
 **Success Criteria**: Existing translated documentation pages are reachable from navigation with English labels in the English build.
 **Tests**: MkDocs strict build.
-**Status**: Not Started
+**Status**: Complete

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,17 @@
+## Stage 1: README English Defaults
+**Goal**: Make the default repository README files English while preserving Korean variants where useful.
+**Success Criteria**: Root, demo, e2e, and frontend README entry points no longer present Korean as the default reader experience.
+**Tests**: Markdown link sanity check and Korean-text scan for the updated README entry points.
+**Status**: Complete
+
+## Stage 2: Frontend UI English Copy
+**Goal**: Translate user-facing Korean strings in the Svelte frontend to English.
+**Success Criteria**: `saegim-frontend/src` has no Korean UI copy except intentional sample/document text values.
+**Tests**: Korean-text scan across frontend source, plus frontend type check and unit tests.
+**Status**: Not Started
+
+## Stage 3: Documentation Navigation I18n
+**Goal**: Improve MkDocs navigation coverage and English nav labels for translated documentation.
+**Success Criteria**: Existing translated documentation pages are reachable from navigation with English labels in the English build.
+**Tests**: MkDocs strict build.
+**Status**: Not Started

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -8,7 +8,7 @@
 **Goal**: Translate user-facing Korean strings in the Svelte frontend to English.
 **Success Criteria**: `saegim-frontend/src` has no Korean UI copy except intentional sample/document text values.
 **Tests**: Korean-text scan across frontend source, plus frontend type check and unit tests.
-**Status**: Not Started
+**Status**: Complete
 
 ## Stage 3: Documentation Navigation I18n
 **Goal**: Improve MkDocs navigation coverage and English nav labels for translated documentation.

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # saegim
 
-> [한국어](README.md) | **English**
+> [Korean](README.ko.md) | **English**
 
 A Human-in-the-Loop labeling platform for Korean document VLM benchmarks.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,117 @@
+# saegim (새김)
+
+> [English](README.md) | **한국어**
+
+한국어 문서 VLM 벤치마크를 위한 Human-in-the-Loop 레이블링 플랫폼.
+
+PDF 문서를 업로드하면 페이지별 이미지로 변환하고,
+웹 기반 에디터에서 레이아웃 요소의 바운딩 박스·카테고리·속성을 레이블링하여
+[OmniDocBench](https://github.com/opendatalab/OmniDocBench) 표준 JSON으로 내보내는 도구입니다.
+
+## Key Features
+
+### 프로젝트 설정 & PDF 업로드
+
+프로젝트를 생성하고, OCR 엔진을 설정한 뒤, PDF를 업로드하면 페이지별 이미지로 자동 변환합니다.
+
+<img src="demo/output/Project-setup.gif" width="100%" alt="Project Setup">
+
+### 레이블 에디터
+
+AI OCR로 자동 추출된 레이아웃 요소를 검토하고, 바운딩 박스 그리기·요소 인덱스 오버레이·읽기 순서 편집 등 다양한 도구로 레이블링합니다.
+
+<img src="demo/output/Label-editor-extraction-annotation-overlays.gif" width="100%" alt="Project Setup">
+
+### 프로젝트 개요 & 내보내기
+
+작업 현황 대시보드에서 진행률을 확인하고, OmniDocBench 표준 JSON으로 내보냅니다.
+
+<img src="demo/output/Project-overview-dashboard-and-export.gif" width="100%" alt="Project Setup">
+
+## 상세 기능
+
+- **PDF 변환** — PDF를 페이지별 고해상도 PNG로 자동 변환
+- **다중 OCR 엔진** — 프로젝트별 엔진 등록·관리 (Gemini API, vLLM, Docling+OCR, pdfminer)
+- **자동 속성 분류** — 페이지/테이블/텍스트/수식 속성 자동 분류
+- **캔버스 에디터** — 바운딩 박스 생성·편집·삭제, 줌/패닝, 키보드 단축키
+- **읽기 순서 에디터** — 드래그앤드롭 재정렬 + 캔버스 오버레이
+- **관계 도구** — 요소 간 관계 CRUD + SVG 화살표 시각화
+- **OmniDocBench 레이블링** — 15종 Block-level + 4종 Span-level 카테고리
+- **인증/인가** — JWT 기반 인증, 시스템 역할 (admin/annotator/reviewer)
+- **관리자 대시보드** — 유저/프로젝트/시스템 통계 관리
+- **JSON Export** — OmniDocBench 표준 포맷으로 내보내기
+
+## Quickstart
+
+### Docker Compose (권장)
+
+Docker만 설치되어 있으면 3단계로 바로 시작할 수 있습니다.
+
+```bash
+# 1. 환경 변수 설정
+cp .env.example .env
+
+# 2. 빌드 + 실행
+make up
+# 또는: docker compose up -d --build
+
+# 3. 브라우저에서 접속
+#    프론트엔드: http://localhost:13000
+#    API 문서:   http://localhost:15000/docs
+```
+
+GPU 모드가 필요하다면 NVIDIA Container Toolkit 설치 후:
+
+```bash
+make up-gpu
+```
+
+### 로컬 개발 환경
+
+```bash
+# 백엔드
+cd saegim-backend
+uv sync --group dev --group docs --extra cpu    # CPU (또는 --extra cu128)
+uv run uvicorn saegim.app:app --reload --host 0.0.0.0 --port 5000
+
+# 프론트엔드
+cd saegim-frontend
+bun install && bun run dev
+```
+
+로컬 접속: 프론트엔드 `http://localhost:5173` / API 문서 `http://localhost:5000/docs`
+
+> 데이터베이스 설정, 마이그레이션 등 상세 가이드는 [백엔드 시작하기](docs/ko/backend/guide/getting-started.md)를 참고하세요.
+
+## Documentation
+
+| 문서 | 설명 |
+| ---- | ---- |
+| [아키텍처 개요](docs/ko/architecture/README.md) | 시스템 구조, 기술 스택, 인증 |
+| [백엔드 아키텍처](docs/ko/backend/architecture/architecture.md) | 레이어드 아키텍처, 데이터 흐름 |
+| [프론트엔드 아키텍처](docs/ko/frontend/architecture/architecture.md) | 컴포넌트 구조, 상태 관리 |
+| [API 가이드](docs/ko/backend/guide/api.md) | REST API 엔드포인트 |
+| [추출 파이프라인](docs/ko/architecture/extraction-pipeline.md) | OCR 엔진 아키텍처 |
+| [데이터 스키마](docs/ko/architecture/data-schema.md) | DB 구조, OmniDocBench 포맷 |
+| [멀티유저 협업](docs/ko/architecture/multi-user-collaboration.md) | 인증, 역할, 태스크 워크플로우 |
+| [배포 가이드](docs/ko/deployment/quickstart.md) | Docker, Kubernetes |
+| [플래닝 가이드](AGENTS.md) | 프로젝트 비전, 로드맵 |
+
+## 개발
+
+```bash
+# 백엔드
+uv run ruff format                  # 포맷팅
+uv run ruff check --fix             # 린트
+uv run ty check                     # 타입 체크
+uv run pytest --cov                 # 테스트 + 커버리지
+
+# 프론트엔드
+bun run check                       # 타입 체크
+bun run test                        # 테스트
+bun run build                       # 프로덕션 빌드
+```
+
+## 라이선스
+
+Apache-2.0 License

--- a/README.md
+++ b/README.md
@@ -1,117 +1,125 @@
-# saegim (새김)
+# saegim
 
-> [English](README.en.md) | **한국어**
+> [Korean](README.ko.md) | **English**
 
-한국어 문서 VLM 벤치마크를 위한 Human-in-the-Loop 레이블링 플랫폼.
+A Human-in-the-Loop labeling platform for Korean document VLM benchmarks.
 
-PDF 문서를 업로드하면 페이지별 이미지로 변환하고,
-웹 기반 에디터에서 레이아웃 요소의 바운딩 박스·카테고리·속성을 레이블링하여
-[OmniDocBench](https://github.com/opendatalab/OmniDocBench) 표준 JSON으로 내보내는 도구입니다.
+Upload PDF documents, automatically convert them into per-page images,
+and label bounding boxes, categories, and attributes of layout elements
+in a web-based editor to export as
+[OmniDocBench](https://github.com/opendatalab/OmniDocBench)-standard JSON.
 
 ## Key Features
 
-### 프로젝트 설정 & PDF 업로드
+### Project Setup & PDF Upload
 
-프로젝트를 생성하고, OCR 엔진을 설정한 뒤, PDF를 업로드하면 페이지별 이미지로 자동 변환합니다.
+Create a project, configure an OCR engine, and upload PDFs to
+automatically convert them into per-page images.
 
 <img src="demo/output/Project-setup.gif" width="100%" alt="Project Setup">
 
-### 레이블 에디터
+### Label Editor
 
-AI OCR로 자동 추출된 레이아웃 요소를 검토하고, 바운딩 박스 그리기·요소 인덱스 오버레이·읽기 순서 편집 등 다양한 도구로 레이블링합니다.
+Review layout elements automatically extracted by AI OCR, and annotate
+them using a variety of tools including bounding box drawing, element
+index overlays, and reading order editing.
 
 <img src="demo/output/Label-editor-extraction-annotation-overlays.gif" width="100%" alt="Project Setup">
 
-### 프로젝트 개요 & 내보내기
+### Project Overview & Export
 
-작업 현황 대시보드에서 진행률을 확인하고, OmniDocBench 표준 JSON으로 내보냅니다.
+Monitor progress on the task dashboard and export to
+OmniDocBench-standard JSON.
 
 <img src="demo/output/Project-overview-dashboard-and-export.gif" width="100%" alt="Project Setup">
 
-## 상세 기능
+## Detailed Features
 
-- **PDF 변환** — PDF를 페이지별 고해상도 PNG로 자동 변환
-- **다중 OCR 엔진** — 프로젝트별 엔진 등록·관리 (Gemini API, vLLM, Docling+OCR, pdfminer)
-- **자동 속성 분류** — 페이지/테이블/텍스트/수식 속성 자동 분류
-- **캔버스 에디터** — 바운딩 박스 생성·편집·삭제, 줌/패닝, 키보드 단축키
-- **읽기 순서 에디터** — 드래그앤드롭 재정렬 + 캔버스 오버레이
-- **관계 도구** — 요소 간 관계 CRUD + SVG 화살표 시각화
-- **OmniDocBench 레이블링** — 15종 Block-level + 4종 Span-level 카테고리
-- **인증/인가** — JWT 기반 인증, 시스템 역할 (admin/annotator/reviewer)
-- **관리자 대시보드** — 유저/프로젝트/시스템 통계 관리
-- **JSON Export** — OmniDocBench 표준 포맷으로 내보내기
+- **PDF Conversion** — Automatically convert PDFs to high-resolution per-page PNGs
+- **Multiple OCR Engines** — Register and manage engines per project
+  (Gemini API, vLLM, Docling+OCR, pdfminer)
+- **Automatic Attribute Classification** — Auto-classify page, table, text, and formula attributes
+- **Canvas Editor** — Create, edit, and delete bounding boxes with zoom/pan and keyboard shortcuts
+- **Reading Order Editor** — Drag-and-drop reordering with canvas overlay
+- **Relation Tool** — Element relation CRUD with SVG arrow visualization
+- **OmniDocBench Labeling** — 15 Block-level + 4 Span-level categories
+- **Authentication & Authorization** — JWT-based auth with system roles
+  (admin/annotator/reviewer)
+- **Admin Dashboard** — User, project, and system statistics management
+- **JSON Export** — Export in OmniDocBench-standard format
 
 ## Quickstart
 
-### Docker Compose (권장)
+### Docker Compose (Recommended)
 
-Docker만 설치되어 있으면 3단계로 바로 시작할 수 있습니다.
+Get started in 3 steps with just Docker installed.
 
 ```bash
-# 1. 환경 변수 설정
+# 1. Set up environment variables
 cp .env.example .env
 
-# 2. 빌드 + 실행
+# 2. Build + run
 make up
-# 또는: docker compose up -d --build
+# or: docker compose up -d --build
 
-# 3. 브라우저에서 접속
-#    프론트엔드: http://localhost:13000
-#    API 문서:   http://localhost:15000/docs
+# 3. Open in browser
+#    Frontend: http://localhost:13000
+#    API docs: http://localhost:15000/docs
 ```
 
-GPU 모드가 필요하다면 NVIDIA Container Toolkit 설치 후:
+If you need GPU mode, install NVIDIA Container Toolkit first:
 
 ```bash
 make up-gpu
 ```
 
-### 로컬 개발 환경
+### Local Development
 
 ```bash
-# 백엔드
+# Backend
 cd saegim-backend
-uv sync --group dev --group docs --extra cpu    # CPU (또는 --extra cu128)
+uv sync --group dev --group docs --extra cpu    # CPU (or --extra cu128)
 uv run uvicorn saegim.app:app --reload --host 0.0.0.0 --port 5000
 
-# 프론트엔드
+# Frontend
 cd saegim-frontend
 bun install && bun run dev
 ```
 
-로컬 접속: 프론트엔드 `http://localhost:5173` / API 문서 `http://localhost:5000/docs`
+Local access: Frontend `http://localhost:5173` / API docs `http://localhost:5000/docs`
 
-> 데이터베이스 설정, 마이그레이션 등 상세 가이드는 [백엔드 시작하기](docs/ko/backend/guide/getting-started.md)를 참고하세요.
+> For database setup, migrations, and other detailed guides, see
+> [Backend Getting Started](docs/en/backend/guide/getting-started.md).
 
 ## Documentation
 
-| 문서 | 설명 |
+| Document | Description |
 | ---- | ---- |
-| [아키텍처 개요](docs/ko/architecture/README.md) | 시스템 구조, 기술 스택, 인증 |
-| [백엔드 아키텍처](docs/ko/backend/architecture/architecture.md) | 레이어드 아키텍처, 데이터 흐름 |
-| [프론트엔드 아키텍처](docs/ko/frontend/architecture/architecture.md) | 컴포넌트 구조, 상태 관리 |
-| [API 가이드](docs/ko/backend/guide/api.md) | REST API 엔드포인트 |
-| [추출 파이프라인](docs/ko/architecture/extraction-pipeline.md) | OCR 엔진 아키텍처 |
-| [데이터 스키마](docs/ko/architecture/data-schema.md) | DB 구조, OmniDocBench 포맷 |
-| [멀티유저 협업](docs/ko/architecture/multi-user-collaboration.md) | 인증, 역할, 태스크 워크플로우 |
-| [배포 가이드](docs/ko/deployment/quickstart.md) | Docker, Kubernetes |
-| [플래닝 가이드](AGENTS.md) | 프로젝트 비전, 로드맵 |
+| [Architecture Overview](docs/en/architecture/README.md) | System structure, tech stack, authentication |
+| [Backend Architecture](docs/en/backend/architecture/architecture.md) | Layered architecture, data flow |
+| [Frontend Architecture](docs/en/frontend/architecture/architecture.md) | Component structure, state management |
+| [API Guide](docs/en/backend/guide/api.md) | REST API endpoints |
+| [Extraction Pipeline](docs/en/architecture/extraction-pipeline.md) | OCR engine architecture |
+| [Data Schema](docs/en/architecture/data-schema.md) | DB structure, OmniDocBench format |
+| [Multi-User Collaboration](docs/en/architecture/multi-user-collaboration.md) | Auth, roles, task workflow |
+| [Deployment Guide](docs/en/deployment/quickstart.md) | Docker, Kubernetes |
+| [Planning Guide](AGENTS.md) | Project vision, roadmap |
 
-## 개발
+## Development
 
 ```bash
-# 백엔드
-uv run ruff format                  # 포맷팅
-uv run ruff check --fix             # 린트
-uv run ty check                     # 타입 체크
-uv run pytest --cov                 # 테스트 + 커버리지
+# Backend
+uv run ruff format                  # Formatting
+uv run ruff check --fix             # Lint
+uv run ty check                     # Type check
+uv run pytest --cov                 # Test + coverage
 
-# 프론트엔드
-bun run check                       # 타입 체크
-bun run test                        # 테스트
-bun run build                       # 프로덕션 빌드
+# Frontend
+bun run check                       # Type check
+bun run test                        # Test
+bun run build                       # Production build
 ```
 
-## 라이선스
+## License
 
 Apache-2.0 License

--- a/demo/README.en.md
+++ b/demo/README.en.md
@@ -1,6 +1,6 @@
 # saegim Demo Recording
 
-> [한국어](README.md) | **English**
+> [Korean](README.ko.md) | **English**
 
 Automatically demonstrates key features using Playwright and converts them to GIFs.
 

--- a/demo/README.ko.md
+++ b/demo/README.ko.md
@@ -1,0 +1,81 @@
+# saegim Demo Recording
+
+> [English](README.md) | **한국어**
+
+Playwright로 주요 기능을 자동 시연하고 GIF로 변환합니다.
+
+## 사전 준비
+
+```bash
+# 1. Docker Compose로 서비스 실행
+cd .. && make up
+
+# 2. 서비스 헬스체크 확인
+curl -f http://localhost:15000/api/v1/health
+
+# 3. Playwright 설치
+cd demo
+bun install
+bunx playwright install chromium
+```
+
+## 녹화
+
+### 기능별 개별 녹화 (권장)
+
+각 기능별로 별도 영상이 생성됩니다. 로그인/설정은 영상에 포함되지 않습니다.
+
+```bash
+# 전체 기능 데모 (setup -> project-setup -> labeling -> overview)
+bunx playwright test --project=setup --project=demo-project-setup --project=demo-labeling --project=demo-overview
+
+# 개별 기능만 녹화
+bunx playwright test --project=setup --project=demo-project-setup   # 프로젝트 생성 + OCR + 업로드
+bunx playwright test --project=setup --project=demo-labeling        # 레이블 에디터
+bunx playwright test --project=setup --project=demo-overview        # 프로젝트 개요 + 내보내기
+```
+
+### 올인원 녹화 (레거시)
+
+전체 흐름을 하나의 영상으로 녹화합니다 (로그인 포함).
+
+```bash
+bunx playwright test --project=demo
+```
+
+영상은 `test-results/` 디렉토리에 `.webm` 파일로 저장됩니다 (1920x1080).
+
+## 데모 프로젝트 구조
+
+| 파일 | 내용 | 영상 |
+| ------ | ------ | ------ |
+| `auth-setup.ts` | 로그인 + 다크모드 + storageState 저장 | 없음 |
+| `demo-project-setup.spec.ts` | 프로젝트 생성 -> OCR 설정 -> PDF 업로드 | O |
+| `demo-labeling.spec.ts` | OCR 추출 수락 -> 요소 검사 -> element index -> bbox -> reading order -> 저장 | O |
+| `demo-overview.spec.ts` | 작업 현황 대시보드 -> 내보내기 | O |
+| `record-demo.ts` | 올인원 레거시 (전체 흐름) | O |
+| `helpers.ts` | 공통 유틸리티 + API 헬퍼 | - |
+
+## GIF 변환
+
+```bash
+bash convert-to-gif.sh                              # test-results/ -> output/ (이름 보존, 800px, 12fps)
+bash convert-to-gif.sh output/                       # output/ 내 webm -> 같은 디렉토리에 gif
+bash convert-to-gif.sh video.webm                    # 단일 파일 변환
+bash convert-to-gif.sh test-results/ gifs/ 640 8     # 작은 파일 (GitHub용)
+bash convert-to-gif.sh test-results/ gifs/ 1280 15   # 고화질
+```
+
+## 커스터마이징
+
+- **속도 조절**: `helpers.ts`의 `PAUSE_*` 상수와 `playwright.config.ts`의 `slowMo` 조절
+- **시나리오 추가**: 각 spec 파일에 `test.step()` 블록 추가
+
+## 환경 변수
+
+| 변수 | 기본값 | 설명 |
+| ------ | -------- | ------ |
+| `BASE_URL` | `http://localhost:13000` | 프론트엔드 URL |
+| `API_URL` | `http://localhost:15000` | 백엔드 API URL |
+| `ADMIN_PASSWORD` | (auto-detect) | 관리자 비밀번호 |
+| `GEMINI_API_KEY` | (from .env) | Gemini API 키 |

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,81 +1,81 @@
 # saegim Demo Recording
 
-> [English](README.en.md) | **한국어**
+> [Korean](README.ko.md) | **English**
 
-Playwright로 주요 기능을 자동 시연하고 GIF로 변환합니다.
+Automatically demonstrates key features using Playwright and converts them to GIFs.
 
-## 사전 준비
+## Prerequisites
 
 ```bash
-# 1. Docker Compose로 서비스 실행
+# 1. Start services with Docker Compose
 cd .. && make up
 
-# 2. 서비스 헬스체크 확인
+# 2. Verify service health check
 curl -f http://localhost:15000/api/v1/health
 
-# 3. Playwright 설치
+# 3. Install Playwright
 cd demo
 bun install
 bunx playwright install chromium
 ```
 
-## 녹화
+## Recording
 
-### 기능별 개별 녹화 (권장)
+### Per-feature recording (recommended)
 
-각 기능별로 별도 영상이 생성됩니다. 로그인/설정은 영상에 포함되지 않습니다.
+A separate video is generated for each feature. Login/setup steps are not included in the videos.
 
 ```bash
-# 전체 기능 데모 (setup → project-setup → labeling → overview)
+# Full feature demo (setup -> project-setup -> labeling -> overview)
 bunx playwright test --project=setup --project=demo-project-setup --project=demo-labeling --project=demo-overview
 
-# 개별 기능만 녹화
-bunx playwright test --project=setup --project=demo-project-setup   # 프로젝트 생성 + OCR + 업로드
-bunx playwright test --project=setup --project=demo-labeling        # 레이블 에디터
-bunx playwright test --project=setup --project=demo-overview        # 프로젝트 개요 + 내보내기
+# Record individual features
+bunx playwright test --project=setup --project=demo-project-setup   # Project creation + OCR + upload
+bunx playwright test --project=setup --project=demo-labeling        # Label editor
+bunx playwright test --project=setup --project=demo-overview        # Project overview + export
 ```
 
-### 올인원 녹화 (레거시)
+### All-in-one recording (legacy)
 
-전체 흐름을 하나의 영상으로 녹화합니다 (로그인 포함).
+Records the entire flow as a single video (including login).
 
 ```bash
 bunx playwright test --project=demo
 ```
 
-영상은 `test-results/` 디렉토리에 `.webm` 파일로 저장됩니다 (1920x1080).
+Videos are saved as `.webm` files in the `test-results/` directory (1920x1080).
 
-## 데모 프로젝트 구조
+## Demo Project Structure
 
-| 파일 | 내용 | 영상 |
+| File | Description | Video |
 | ------ | ------ | ------ |
-| `auth-setup.ts` | 로그인 + 다크모드 + storageState 저장 | 없음 |
-| `demo-project-setup.spec.ts` | 프로젝트 생성 → OCR 설정 → PDF 업로드 | O |
-| `demo-labeling.spec.ts` | OCR 추출 수락 → 요소 검사 → element index → bbox → reading order → 저장 | O |
-| `demo-overview.spec.ts` | 작업 현황 대시보드 → 내보내기 | O |
-| `record-demo.ts` | 올인원 레거시 (전체 흐름) | O |
-| `helpers.ts` | 공통 유틸리티 + API 헬퍼 | - |
+| `auth-setup.ts` | Login + dark mode + save storageState | None |
+| `demo-project-setup.spec.ts` | Create project -> OCR setup -> PDF upload | Yes |
+| `demo-labeling.spec.ts` | Accept OCR extraction -> inspect elements -> element index -> bbox -> reading order -> save | Yes |
+| `demo-overview.spec.ts` | Task status dashboard -> export | Yes |
+| `record-demo.ts` | All-in-one legacy (full flow) | Yes |
+| `helpers.ts` | Common utilities + API helpers | - |
 
-## GIF 변환
+## GIF Conversion
 
 ```bash
-bash convert-to-gif.sh                              # test-results/ → output/ (이름 보존, 800px, 12fps)
-bash convert-to-gif.sh output/                       # output/ 내 webm → 같은 디렉토리에 gif
-bash convert-to-gif.sh video.webm                    # 단일 파일 변환
-bash convert-to-gif.sh test-results/ gifs/ 640 8     # 작은 파일 (GitHub용)
-bash convert-to-gif.sh test-results/ gifs/ 1280 15   # 고화질
+bash convert-to-gif.sh                              # test-results/ -> output/ (preserve names, 800px, 12fps)
+bash convert-to-gif.sh output/                       # webm in output/ -> gif in the same directory
+bash convert-to-gif.sh video.webm                    # Convert a single file
+bash convert-to-gif.sh test-results/ gifs/ 640 8     # Smaller files (for GitHub)
+bash convert-to-gif.sh test-results/ gifs/ 1280 15   # High quality
 ```
 
-## 커스터마이징
+## Customization
 
-- **속도 조절**: `helpers.ts`의 `PAUSE_*` 상수와 `playwright.config.ts`의 `slowMo` 조절
-- **시나리오 추가**: 각 spec 파일에 `test.step()` 블록 추가
+- **Speed control**: Adjust `PAUSE_*` constants in `helpers.ts` and `slowMo` in `playwright.config.ts`
+- **Add scenarios**: Add `test.step()` blocks in each spec file
 
-## 환경 변수
+## Environment Variables
 
-| 변수 | 기본값 | 설명 |
+| Variable | Default | Description |
 | ------ | -------- | ------ |
-| `BASE_URL` | `http://localhost:13000` | 프론트엔드 URL |
-| `API_URL` | `http://localhost:15000` | 백엔드 API URL |
-| `ADMIN_PASSWORD` | (auto-detect) | 관리자 비밀번호 |
-| `GEMINI_API_KEY` | (from .env) | Gemini API 키 |
+| `BASE_URL` | `http://localhost:13000` | Frontend URL |
+| `API_URL` | `http://localhost:15000` | Backend API URL |
+| `ADMIN_PASSWORD` | (auto-detect) | Admin password |
+| `GEMINI_API_KEY` | (from .env) | Gemini API key |

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,7 +1,5 @@
 # saegim
 
-> [한국어](../ko/README.md) | **English**
-
 Human-in-the-Loop Labeling Platform for Korean Document VLM Benchmarks.
 
 Upload PDF documents to automatically convert them into per-page images,
@@ -187,5 +185,5 @@ bun run docker:gpu:up && bun run test:gpu  # GPU tests
 | [API Guide](backend/guide/api.md) | REST API endpoints (including Auth, Admin) |
 | [Multi-User Collaboration](architecture/multi-user-collaboration.md) | Authentication, roles, task workflow |
 | [Backend Getting Started](backend/guide/getting-started.md) | Development environment setup |
-| [E2E Testing](../e2e/README.md) | E2E testing guide |
-| [Planning Guide](../AGENTS.md) | Project vision, roadmap |
+| [E2E Testing](https://github.com/appleparan/saegim/blob/main/e2e/README.md) | E2E testing guide |
+| [Planning Guide](https://github.com/appleparan/saegim/blob/main/AGENTS.md) | Project vision, roadmap |

--- a/docs/en/backend/architecture/database.md
+++ b/docs/en/backend/architecture/database.md
@@ -313,7 +313,7 @@ During export, collecting this column into an array directly produces the final 
 }
 ```
 
-Type definitions: [saegim-frontend/src/lib/types/omnidocbench.ts](../../saegim-frontend/src/lib/types/omnidocbench.ts)
+Type definitions: [saegim-frontend/src/lib/types/omnidocbench.ts](https://github.com/appleparan/saegim/blob/main/saegim-frontend/src/lib/types/omnidocbench.ts)
 
 Schema details: [Data Schema](../../architecture/data-schema.md)
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,7 +1,5 @@
 # saegim (새김)
 
-> [English](../en/README.md) | **한국어**
-
 한국어 문서 VLM 벤치마크를 위한 Human-in-the-Loop 레이블링 플랫폼.
 
 PDF 문서를 업로드하면 페이지별 이미지로 변환하고,
@@ -186,5 +184,5 @@ bun run docker:gpu:up && bun run test:gpu  # GPU 테스트
 | [API 가이드](backend/guide/api.md) | REST API 엔드포인트 (Auth, Admin 포함) |
 | [멀티유저 협업](architecture/multi-user-collaboration.md) | 인증, 역할, 태스크 워크플로우 |
 | [백엔드 시작하기](backend/guide/getting-started.md) | 개발 환경 설정 |
-| [E2E 테스트](../e2e/README.md) | E2E 테스트 가이드 |
-| [플래닝 가이드](../AGENTS.md) | 프로젝트 비전, 로드맵 |
+| [E2E 테스트](https://github.com/appleparan/saegim/blob/main/e2e/README.ko.md) | E2E 테스트 가이드 |
+| [플래닝 가이드](https://github.com/appleparan/saegim/blob/main/AGENTS.md) | 프로젝트 비전, 로드맵 |

--- a/docs/ko/backend/architecture/database.md
+++ b/docs/ko/backend/architecture/database.md
@@ -313,7 +313,7 @@ Export 시 이 컬럼을 모아서 배열로 만들면 바로 최종 JSON이 된
 }
 ```
 
-타입 정의: [saegim-frontend/src/lib/types/omnidocbench.ts](../../saegim-frontend/src/lib/types/omnidocbench.ts)
+타입 정의: [saegim-frontend/src/lib/types/omnidocbench.ts](https://github.com/appleparan/saegim/blob/main/saegim-frontend/src/lib/types/omnidocbench.ts)
 
 스키마 상세: [데이터 스키마](../../architecture/data-schema.md)
 

--- a/e2e/README.en.md
+++ b/e2e/README.en.md
@@ -1,6 +1,6 @@
 # E2E Tests
 
-> [한국어](README.md) | **English**
+> [Korean](README.ko.md) | **English**
 
 End-to-end tests based on Vitest. Spins up the full stack (postgres, backend, frontend) via Docker Compose
 and verifies the API.

--- a/e2e/README.ko.md
+++ b/e2e/README.ko.md
@@ -1,0 +1,131 @@
+# E2E Tests
+
+> [English](README.md) | **한국어**
+
+Vitest 기반 end-to-end 테스트. Docker Compose로 전체 스택(postgres, backend, frontend)을 띄우고 API를 검증한다.
+
+## 사전 준비
+
+```bash
+cd e2e
+bun install
+```
+
+## 기본 테스트 (GPU 불필요)
+
+기본 프로파일은 postgres + backend + frontend만 실행한다. pdfminer.six 폴백으로 OCR 추출하므로 GPU가 필요 없다.
+
+```bash
+# 1. 서비스 시작
+bun run docker:up
+
+# 2. 테스트 실행
+bun run test
+
+# 3. 개별 테스트 실행
+bun run test:health        # health check
+bun run test:extraction    # pdfminer 추출 → 수락 워크플로우
+bun run test:ocr-config    # OCR 엔진 설정 API
+bun run test:attribute     # 속성 분류기
+bun run test:reading-order # 읽기 순서 CRUD
+bun run test:relations     # 관계 CRUD
+bun run test:re-extract    # 문서 재추출 + 강제 수락
+bun run test:benchmark     # API 벤치마크
+bun run test:browser:mcp   # chrome-devtools MCP 브라우저 E2E (로그인/ID 중복체크)
+
+# 4. 정리
+bun run docker:down
+```
+
+## GPU 테스트 (vLLM + Chandra)
+
+`gpu` 프로파일은 기본 서비스에 vLLM 서버를 추가한다. vLLM은 `prithivMLmods/chandra-FP8-Latest` 모델을 로드하며,
+**24GB+ VRAM GPU**가 필요하다.
+
+### 요구사항
+
+- NVIDIA GPU (24GB+ VRAM, e.g. RTX 4090, A5000, A6000)
+- NVIDIA Container Toolkit (`nvidia-docker2`)
+- 첫 실행 시 모델 다운로드 (~18GB)
+
+### 실행
+
+```bash
+# 1. GPU 프로파일로 서비스 시작
+bun run docker:gpu:up
+
+# 2. vLLM 모델 로딩 대기 (첫 실행 시 다운로드 포함 10-30분)
+#    로그로 진행 상황 확인:
+docker compose -f docker-compose.e2e.yml --profile gpu logs -f vllm
+
+# 3. GPU 테스트 실행
+bun run test:gpu
+
+# 4. 정리
+bun run docker:gpu:down
+```
+
+### HuggingFace 캐시
+
+모델 다운로드를 영속화하려면 `HF_CACHE_DIR` 환경변수를 설정한다:
+
+```bash
+# 기본값: ~/.cache/huggingface
+export HF_CACHE_DIR=/data/models/huggingface
+bun run docker:gpu:up
+```
+
+## 테스트 구조
+
+```text
+e2e/
+├── docker-compose.e2e.yml    # Docker Compose (기본 + gpu 프로파일)
+├── vitest.config.ts          # Vitest 설정 (기본 테스트)
+├── vitest.gpu.config.ts      # Vitest 설정 (GPU 테스트)
+├── package.json
+├── helpers/
+│   ├── api.ts                # API 헬퍼 (CRUD, OCR config, vLLM health)
+│   ├── pdf.ts                # 테스트 PDF 다운로드 (attention.pdf)
+│   └── timer.ts              # 벤치마크 타이머
+├── tests/
+│   ├── health.test.ts              # 서비스 health check
+│   ├── extraction.test.ts          # pdfminer 추출 → 수락 워크플로우
+│   ├── ocr-config.test.ts          # OCR 엔진 설정 API (다중 인스턴스 CRUD + validation)
+│   ├── attribute-classifier.test.ts  # 속성 분류기
+│   ├── reading-order.test.ts       # 읽기 순서 CRUD + 유효성 검증
+│   ├── relations.test.ts           # 관계 CRUD + 충돌 검증
+│   ├── re-extract.test.ts          # 문서 재추출 + 강제 수락
+│   ├── benchmark.test.ts           # API 응답시간 벤치마크
+│   └── gpu/
+│       ├── vllm-extraction.test.ts       # vLLM chandra 추출 (GPU 전용)
+│       └── hybrid-labeling-gpu.test.ts   # 하이브리드 레이블링 (GPU 전용)
+└── fixtures/
+    └── attention.pdf         # 테스트 PDF (자동 다운로드)
+```
+
+## Docker Compose 서비스
+
+| 서비스 | 프로파일 | 포트 | 설명 |
+| -------- | -------- | ----- | -------------------------------------------- |
+| postgres | 기본 | 25432 | PostgreSQL 18 |
+| backend | 기본 | 25000 | FastAPI 서버 |
+| frontend | 기본 | 23000 | SvelteKit (Nginx) |
+| vllm | gpu | 28000 | vLLM OpenAI API (prithivMLmods/chandra-FP8-Latest) |
+
+## 환경변수
+
+| 변수 | 기본값 | 설명 |
+| ----------------- | ----------------------- | ----------------------------- |
+| `E2E_BACKEND_URL` | `http://localhost:25000` | 백엔드 API URL |
+| `E2E_FRONTEND_URL` | `http://localhost:23000` | 프론트엔드 URL |
+| `E2E_VLLM_URL` | `http://localhost:28000` | vLLM API URL |
+| `HF_CACHE_DIR` | `~/.cache/huggingface` | HuggingFace 모델 캐시 경로 |
+
+## Vitest 설정
+
+| 설정 파일 | 매칭 패턴 | Timeout | 설명 |
+| -------------------- | -------------------- | ------- | -------------------- |
+| `vitest.config.ts` | `tests/**/*.test.ts` (gpu/ 제외) | 2분 | 기본 테스트 |
+| `vitest.gpu.config.ts` | `tests/gpu/**/*.test.ts` | 10분 | GPU 전용 (vLLM 추출) |
+
+`bun run test`는 기본 설정으로 실행하고, `bun run test:gpu`는 GPU 설정으로 실행한다.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,131 +1,133 @@
 # E2E Tests
 
-> [English](README.en.md) | **한국어**
+> [Korean](README.ko.md) | **English**
 
-Vitest 기반 end-to-end 테스트. Docker Compose로 전체 스택(postgres, backend, frontend)을 띄우고 API를 검증한다.
+End-to-end tests based on Vitest. Spins up the full stack (postgres, backend, frontend) via Docker Compose
+and verifies the API.
 
-## 사전 준비
+## Prerequisites
 
 ```bash
 cd e2e
 bun install
 ```
 
-## 기본 테스트 (GPU 불필요)
+## Basic Tests (No GPU Required)
 
-기본 프로파일은 postgres + backend + frontend만 실행한다. pdfminer.six 폴백으로 OCR 추출하므로 GPU가 필요 없다.
+The default profile runs only postgres + backend + frontend. It uses pdfminer.six fallback for OCR
+extraction, so no GPU is needed.
 
 ```bash
-# 1. 서비스 시작
+# 1. Start services
 bun run docker:up
 
-# 2. 테스트 실행
+# 2. Run tests
 bun run test
 
-# 3. 개별 테스트 실행
+# 3. Run individual tests
 bun run test:health        # health check
-bun run test:extraction    # pdfminer 추출 → 수락 워크플로우
-bun run test:ocr-config    # OCR 엔진 설정 API
-bun run test:attribute     # 속성 분류기
-bun run test:reading-order # 읽기 순서 CRUD
-bun run test:relations     # 관계 CRUD
-bun run test:re-extract    # 문서 재추출 + 강제 수락
-bun run test:benchmark     # API 벤치마크
-bun run test:browser:mcp   # chrome-devtools MCP 브라우저 E2E (로그인/ID 중복체크)
+bun run test:extraction    # pdfminer extraction -> accept workflow
+bun run test:ocr-config    # OCR engine configuration API
+bun run test:attribute     # attribute classifier
+bun run test:reading-order # reading order CRUD
+bun run test:relations     # relations CRUD
+bun run test:re-extract    # document re-extraction + force accept
+bun run test:benchmark     # API benchmark
+bun run test:browser:mcp   # chrome-devtools MCP browser E2E (login/ID duplication check)
 
-# 4. 정리
+# 4. Cleanup
 bun run docker:down
 ```
 
-## GPU 테스트 (vLLM + Chandra)
+## GPU Tests (vLLM + Chandra)
 
-`gpu` 프로파일은 기본 서비스에 vLLM 서버를 추가한다. vLLM은 `prithivMLmods/chandra-FP8-Latest` 모델을 로드하며,
-**24GB+ VRAM GPU**가 필요하다.
+The `gpu` profile adds a vLLM server on top of the default services. vLLM loads the
+`prithivMLmods/chandra-FP8-Latest` model and requires a **24GB+ VRAM GPU**.
 
-### 요구사항
+### Requirements
 
 - NVIDIA GPU (24GB+ VRAM, e.g. RTX 4090, A5000, A6000)
 - NVIDIA Container Toolkit (`nvidia-docker2`)
-- 첫 실행 시 모델 다운로드 (~18GB)
+- First run downloads the model (~18GB)
 
-### 실행
+### Running
 
 ```bash
-# 1. GPU 프로파일로 서비스 시작
+# 1. Start services with GPU profile
 bun run docker:gpu:up
 
-# 2. vLLM 모델 로딩 대기 (첫 실행 시 다운로드 포함 10-30분)
-#    로그로 진행 상황 확인:
+# 2. Wait for vLLM model loading (10-30 min on first run including download)
+#    Check progress via logs:
 docker compose -f docker-compose.e2e.yml --profile gpu logs -f vllm
 
-# 3. GPU 테스트 실행
+# 3. Run GPU tests
 bun run test:gpu
 
-# 4. 정리
+# 4. Cleanup
 bun run docker:gpu:down
 ```
 
-### HuggingFace 캐시
+### HuggingFace Cache
 
-모델 다운로드를 영속화하려면 `HF_CACHE_DIR` 환경변수를 설정한다:
+To persist model downloads, set the `HF_CACHE_DIR` environment variable:
 
 ```bash
-# 기본값: ~/.cache/huggingface
+# Default: ~/.cache/huggingface
 export HF_CACHE_DIR=/data/models/huggingface
 bun run docker:gpu:up
 ```
 
-## 테스트 구조
+## Test Structure
 
 ```text
 e2e/
-├── docker-compose.e2e.yml    # Docker Compose (기본 + gpu 프로파일)
-├── vitest.config.ts          # Vitest 설정 (기본 테스트)
-├── vitest.gpu.config.ts      # Vitest 설정 (GPU 테스트)
+├── docker-compose.e2e.yml    # Docker Compose (default + gpu profiles)
+├── vitest.config.ts          # Vitest config (basic tests)
+├── vitest.gpu.config.ts      # Vitest config (GPU tests)
 ├── package.json
 ├── helpers/
-│   ├── api.ts                # API 헬퍼 (CRUD, OCR config, vLLM health)
-│   ├── pdf.ts                # 테스트 PDF 다운로드 (attention.pdf)
-│   └── timer.ts              # 벤치마크 타이머
+│   ├── api.ts                # API helpers (CRUD, OCR config, vLLM health)
+│   ├── pdf.ts                # Test PDF download (attention.pdf)
+│   └── timer.ts              # Benchmark timer
 ├── tests/
-│   ├── health.test.ts              # 서비스 health check
-│   ├── extraction.test.ts          # pdfminer 추출 → 수락 워크플로우
-│   ├── ocr-config.test.ts          # OCR 엔진 설정 API (다중 인스턴스 CRUD + validation)
-│   ├── attribute-classifier.test.ts  # 속성 분류기
-│   ├── reading-order.test.ts       # 읽기 순서 CRUD + 유효성 검증
-│   ├── relations.test.ts           # 관계 CRUD + 충돌 검증
-│   ├── re-extract.test.ts          # 문서 재추출 + 강제 수락
-│   ├── benchmark.test.ts           # API 응답시간 벤치마크
+│   ├── health.test.ts              # Service health check
+│   ├── extraction.test.ts          # pdfminer extraction -> accept workflow
+│   ├── ocr-config.test.ts          # OCR engine config API (multi-instance CRUD + validation)
+│   ├── attribute-classifier.test.ts  # Attribute classifier
+│   ├── reading-order.test.ts       # Reading order CRUD + validation
+│   ├── relations.test.ts           # Relations CRUD + conflict validation
+│   ├── re-extract.test.ts          # Document re-extraction + force accept
+│   ├── benchmark.test.ts           # API response time benchmark
 │   └── gpu/
-│       ├── vllm-extraction.test.ts       # vLLM chandra 추출 (GPU 전용)
-│       └── hybrid-labeling-gpu.test.ts   # 하이브리드 레이블링 (GPU 전용)
+│       ├── vllm-extraction.test.ts       # vLLM chandra extraction (GPU only)
+│       └── hybrid-labeling-gpu.test.ts   # Hybrid labeling (GPU only)
 └── fixtures/
-    └── attention.pdf         # 테스트 PDF (자동 다운로드)
+    └── attention.pdf         # Test PDF (auto-downloaded)
 ```
 
-## Docker Compose 서비스
+## Docker Compose Services
 
-| 서비스 | 프로파일 | 포트 | 설명 |
-| -------- | -------- | ----- | -------------------------------------------- |
-| postgres | 기본 | 25432 | PostgreSQL 18 |
-| backend | 기본 | 25000 | FastAPI 서버 |
-| frontend | 기본 | 23000 | SvelteKit (Nginx) |
+| Service | Profile | Port | Description |
+| -------- | -------- | ----- | ---- |
+| postgres | default | 25432 | PostgreSQL 18 |
+| backend | default | 25000 | FastAPI server |
+| frontend | default | 23000 | SvelteKit (Nginx) |
 | vllm | gpu | 28000 | vLLM OpenAI API (prithivMLmods/chandra-FP8-Latest) |
 
-## 환경변수
+## Environment Variables
 
-| 변수 | 기본값 | 설명 |
-| ----------------- | ----------------------- | ----------------------------- |
-| `E2E_BACKEND_URL` | `http://localhost:25000` | 백엔드 API URL |
-| `E2E_FRONTEND_URL` | `http://localhost:23000` | 프론트엔드 URL |
+| Variable | Default | Description |
+| ---- | ---- | ---- |
+| `E2E_BACKEND_URL` | `http://localhost:25000` | Backend API URL |
+| `E2E_FRONTEND_URL` | `http://localhost:23000` | Frontend URL |
 | `E2E_VLLM_URL` | `http://localhost:28000` | vLLM API URL |
-| `HF_CACHE_DIR` | `~/.cache/huggingface` | HuggingFace 모델 캐시 경로 |
+| `HF_CACHE_DIR` | `~/.cache/huggingface` | HuggingFace model cache path |
 
-## Vitest 설정
+## Vitest Configuration
 
-| 설정 파일 | 매칭 패턴 | Timeout | 설명 |
-| -------------------- | -------------------- | ------- | -------------------- |
-| `vitest.config.ts` | `tests/**/*.test.ts` (gpu/ 제외) | 2분 | 기본 테스트 |
-| `vitest.gpu.config.ts` | `tests/gpu/**/*.test.ts` | 10분 | GPU 전용 (vLLM 추출) |
+| Config File | Match Pattern | Timeout | Description |
+| ---- | ---- | ---- | ---- |
+| `vitest.config.ts` | `tests/**/*.test.ts` (excluding gpu/) | 2 min | Basic tests |
+| `vitest.gpu.config.ts` | `tests/gpu/**/*.test.ts` | 10 min | GPU only (vLLM extraction) |
 
-`bun run test`는 기본 설정으로 실행하고, `bun run test:gpu`는 GPU 설정으로 실행한다.
+`bun run test` runs with the default config, and `bun run test:gpu` runs with the GPU config.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,9 +198,13 @@ markdown_extensions:
 nav:
   - Home: ko/README.md
   - Architecture:
+    - 개요: ko/architecture/README.md
     - 데이터 스키마: ko/architecture/data-schema.md
     - 추출 파이프라인: ko/architecture/extraction-pipeline.md
+    - DocIR 아키텍처: ko/architecture/docir-architecture.md
     - 레이블링 워크플로우: ko/architecture/labeling-workflow.md
+    - 멀티유저 협업: ko/architecture/multi-user-collaboration.md
+    - 데이터 큐레이션: ko/architecture/data-curation.md
   - Backend:
     - Guide:
       - 시작하기: ko/backend/guide/getting-started.md
@@ -243,5 +247,21 @@ plugins:
             Deployment: Deployment
             Guide: Guide
             Dev: Dev
+            개요: Overview
+            데이터 스키마: Data Schema
+            추출 파이프라인: Extraction Pipeline
+            DocIR 아키텍처: DocIR Architecture
+            레이블링 워크플로우: Labeling Workflow
+            멀티유저 협업: Multi-User Collaboration
+            데이터 큐레이션: Data Curation
+            시작하기: Getting Started
+            API 엔드포인트: API Endpoints
+            아키텍처: Architecture
+            데이터베이스: Database
+            개발 가이드: Development Guide
+            컴포넌트: Components
+            단축키: Shortcuts
+            스토어: Stores
+            API 클라이언트: API Client
+            빠른 시작: Quickstart
   - section-index
-

--- a/saegim-backend/README.md
+++ b/saegim-backend/README.md
@@ -1,102 +1,102 @@
 # saegim-backend
 
-saegim 레이블링 플랫폼의 백엔드. FastAPI + asyncpg 기반 REST API 서버.
+Backend for the saegim labeling platform. Provides a FastAPI + asyncpg REST API server.
 
-## 기술 스택
+## Tech Stack
 
-| 분류 | 기술 |
+| Category | Technology |
 | ---- | ---- |
-| **프레임워크** | FastAPI |
-| **DB 드라이버** | asyncpg (raw SQL) |
-| **데이터베이스** | PostgreSQL 15+ (JSONB) |
-| **스키마** | Pydantic |
-| **PDF 처리** | pypdfium2 + pdfminer.six |
-| **OCR** | 4종 Strategy 패턴 (Gemini API, vLLM, Layout+OCR, pdfminer) |
-| **포맷터** | ruff format |
-| **린터** | ruff check |
-| **타입 체커** | ty |
-| **테스트** | pytest |
-| **패키지 관리** | uv |
+| **Framework** | FastAPI |
+| **DB Driver** | asyncpg (raw SQL) |
+| **Database** | PostgreSQL 15+ (JSONB) |
+| **Schema** | Pydantic |
+| **PDF Processing** | pypdfium2 + pdfminer.six |
+| **OCR** | 4-type Strategy pattern (Gemini API, vLLM, Layout+OCR, pdfminer) |
+| **Formatter** | ruff format |
+| **Linter** | ruff check |
+| **Type Checker** | ty |
+| **Tests** | pytest |
+| **Package Management** | uv |
 
-## 프로젝트 구조
+## Project Structure
 
 ```text
 saegim-backend/
 ├── src/saegim/
-│   ├── app.py                    # FastAPI 앱 팩토리
+│   ├── app.py                    # FastAPI app factory
 │   ├── api/
-│   │   └── routes/               # REST 엔드포인트
-│   ├── schemas/                  # Pydantic 모델 (EngineType, OcrConfig 등)
+│   │   └── routes/               # REST endpoints
+│   ├── schemas/                  # Pydantic models (EngineType, OcrConfig, etc.)
 │   ├── services/
-│   │   ├── engines/              # OCR 엔진 Strategy 패턴
+│   │   ├── engines/              # OCR engine Strategy pattern
 │   │   │   ├── base.py           # BaseOCREngine ABC
-│   │   │   ├── factory.py        # build_engine_by_id() 팩토리
+│   │   │   ├── factory.py        # build_engine_by_id() factory
 │   │   │   ├── pdfminer_engine.py
 │   │   │   ├── commercial_api_engine.py
 │   │   │   ├── vllm_engine.py
 │   │   │   └── split_pipeline_engine.py
-│   │   ├── docir.py                 # DocIR 중간 표현 (PageIR, ElementIR 등)
-│   │   ├── adapters/                # 모델별 Adapter (raw → DocIR)
-│   │   │   ├── base.py             # ModelAdapter Protocol
-│   │   │   ├── resolver.py          # resolve_adapter() 자동 선택
-│   │   │   ├── chandra.py           # ChandraAdapter
-│   │   │   ├── lightonocr.py        # LightOnOcrAdapter
-│   │   │   └── paddleocr_vl.py      # PaddleOcrVlAdapter
-│   │   ├── exporters/               # DocIR → 최종 출력 변환
-│   │   │   └── omnidocbench.py      # export_page(PageIR) → OmniDocBench dict
-│   │   ├── layout_types.py          # LayoutRegion, LayoutDetector Protocol
-│   │   ├── docling_layout_service.py # Docling 레이아웃 감지
-│   │   ├── pp_doclayout_service.py  # PP-DocLayoutV3 레이아웃 감지
-│   │   ├── gemini_ocr_service.py    # Gemini VLM 프로바이더
-│   │   ├── vllm_ocr_service.py      # vLLM 프로바이더 (Chandra 등)
-│   │   └── ocr_pipeline.py          # 2단계 파이프라인 오케스트레이터
-│   ├── repositories/             # 데이터 접근 (raw SQL)
-│   └── core/                     # DB 커넥션 풀, 설정
-├── migrations/                   # SQL 마이그레이션
-├── tests/                        # pytest 유닛/통합 테스트
-│   ├── api/                      # API 라우트 테스트
-│   ├── schemas/                  # Pydantic 스키마 테스트
-│   └── services/                 # 서비스 로직 테스트
-├── docs/                         # MkDocs 문서
-└── pyproject.toml                # 프로젝트 설정 (uv, ruff, ty 등)
+│   │   ├── docir.py              # DocIR intermediate representation
+│   │   ├── adapters/             # Model adapters (raw -> DocIR)
+│   │   │   ├── base.py           # ModelAdapter Protocol
+│   │   │   ├── resolver.py       # resolve_adapter() auto-selection
+│   │   │   ├── chandra.py        # ChandraAdapter
+│   │   │   ├── lightonocr.py     # LightOnOcrAdapter
+│   │   │   └── paddleocr_vl.py   # PaddleOcrVlAdapter
+│   │   ├── exporters/            # DocIR -> final output conversion
+│   │   │   └── omnidocbench.py   # export_page(PageIR) -> OmniDocBench dict
+│   │   ├── layout_types.py       # LayoutRegion, LayoutDetector Protocol
+│   │   ├── docling_layout_service.py # Docling layout detection
+│   │   ├── pp_doclayout_service.py   # PP-DocLayoutV3 layout detection
+│   │   ├── gemini_ocr_service.py     # Gemini VLM provider
+│   │   ├── vllm_ocr_service.py       # vLLM provider (Chandra, etc.)
+│   │   └── ocr_pipeline.py           # 2-stage pipeline orchestrator
+│   ├── repositories/             # Data access (raw SQL)
+│   └── core/                     # DB connection pool and settings
+├── migrations/                   # SQL migrations
+├── tests/                        # pytest unit/integration tests
+│   ├── api/                      # API route tests
+│   ├── schemas/                  # Pydantic schema tests
+│   └── services/                 # Service logic tests
+├── docs/                         # MkDocs documentation
+└── pyproject.toml                # Project settings (uv, ruff, ty, etc.)
 ```
 
-## 개발
+## Development
 
 ```bash
 cd saegim-backend
 
-# 환경 설정
+# Environment setup
 uv python install 3.14
 uv python pin 3.14
 uv sync --group dev --group docs
 
-# 서버 실행
+# Run server
 uv run uvicorn saegim.app:app --reload --host 0.0.0.0 --port 5000
 
-# 코드 퀄리티
-uv run ruff format                  # 포맷팅
-uv run ruff check --fix             # 린트
-uv run ty check                     # 타입 체크
-uv run pytest --cov                 # 테스트 + 커버리지
+# Code quality
+uv run ruff format                  # Formatting
+uv run ruff check --fix             # Lint
+uv run ty check                     # Type check
+uv run pytest --cov                 # Tests + coverage
 
-# 문서
-uv run mkdocs serve                 # 로컬 문서 서버
-uv run mkdocs build                 # 문서 빌드
+# Docs
+uv run mkdocs serve                 # Local docs server
+uv run mkdocs build                 # Docs build
 ```
 
-## 릴리스
+## Release
 
 ```bash
 sh scripts/release.sh
 ```
 
-`release.sh`는 다음을 수행한다:
+`release.sh`:
 
-1. `git-cliff`로 다음 버전을 결정
-2. `CHANGELOG.md`와 `RELEASE.md` 생성
-3. 커밋, 태그, 푸시
+1. Determines the next version with `git-cliff`
+2. Generates `CHANGELOG.md` and `RELEASE.md`
+3. Commits, tags, and pushes
 
 ---
 
-*이 프로젝트 템플릿은 [copier-modern-ml](https://github.com/appleparan/copier-modern-ml) 기반으로 생성되었습니다.*
+*This project template was generated from [copier-modern-ml](https://github.com/appleparan/copier-modern-ml).*

--- a/saegim-frontend/README.md
+++ b/saegim-frontend/README.md
@@ -1,55 +1,56 @@
 # saegim-frontend
 
-saegim 레이블링 플랫폼의 프론트엔드. SvelteKit + Svelte 5 Runes 기반 SPA.
+Frontend for the saegim labeling platform. Built as a SvelteKit SPA with Svelte 5 Runes.
 
-## 기술 스택
+## Tech Stack
 
-| 분류 | 기술 |
+| Category | Technology |
 | ---- | ---- |
-| **프레임워크** | SvelteKit (adapter-static SPA) + Svelte 5 (Runes) |
-| **빌드** | Vite 7, TypeScript |
-| **스타일** | Tailwind CSS 4, shadcn-svelte, 다크모드 (mode-watcher) |
-| **캔버스** | PDF.js (PDF 렌더링) + Konva.js (바운딩 박스 에디터) |
-| **포맷터** | oxfmt |
-| **린터** | ESLint |
-| **테스트** | Vitest + Testing Library |
+| **Framework** | SvelteKit (adapter-static SPA) + Svelte 5 (Runes) |
+| **Build** | Vite 7, TypeScript |
+| **Styling** | Tailwind CSS 4, shadcn-svelte, dark mode via mode-watcher |
+| **Canvas** | PDF.js (PDF rendering) + Konva.js (bounding box editor) |
+| **Formatter** | oxfmt |
+| **Linter** | ESLint |
+| **Tests** | Vitest + Testing Library |
 
-## 개발
+## Development
 
 ```bash
+cd saegim-frontend
 bun install
 
-bun run dev           # 개발 서버 (localhost:5173)
-bun run build         # 프로덕션 빌드
-bun run preview       # 빌드 결과 미리보기
-bun run check         # svelte-check 타입 체크
-bun run test          # Vitest 테스트
-bun run format        # oxfmt 포맷팅
-bun run format:check  # 포맷 검사
-bun run lint          # ESLint 검사
-bun run lint:fix      # ESLint 자동 수정
+bun run dev           # Development server (localhost:5173)
+bun run build         # Production build
+bun run preview       # Preview production build
+bun run check         # svelte-check type check
+bun run test          # Vitest tests
+bun run format        # oxfmt formatting
+bun run format:check  # Format check
+bun run lint          # ESLint check
+bun run lint:fix      # Auto-fix ESLint issues
 ```
 
-## 프로젝트 구조
+## Project Structure
 
 ```text
 src/
-├── routes/                   # SvelteKit 파일 기반 라우팅
-│   ├── +layout.svelte        # 루트 레이아웃
-│   ├── +page.svelte          # 홈 (프로젝트 목록)
-│   ├── projects/             # 프로젝트 상세
-│   └── label/                # 레이블링 에디터
-├── lib/
-│   ├── api/                  # HTTP 클라이언트 (백엔드 REST API)
-│   ├── components/
-│   │   ├── ui/               # shadcn-svelte 기본 UI 컴포넌트
-│   │   ├── canvas/           # PDF.js + Konva.js 캔버스 에디터
-│   │   ├── panels/           # 사이드 패널 (속성, 카테고리 등)
-│   │   ├── layout/           # 레이아웃 컴포넌트
-│   │   ├── settings/         # 설정 관련 컴포넌트
-│   │   └── common/           # 공통 컴포넌트
-│   ├── stores/               # Svelte 5 Runes 상태 관리
-│   ├── types/                # OmniDocBench 타입 정의
-│   └── utils/                # 유틸리티 함수
-└── tests/                    # Vitest 유닛 테스트
+├── routes/                   # SvelteKit file-based routing
+│   ├── +layout.svelte        # Root layout
+│   ├── +page.svelte          # Home (project list)
+│   ├── projects/             # Project detail pages
+│   └── label/                # Labeling editor
+└── lib/
+    ├── api/                  # HTTP client for backend REST API
+    ├── components/
+    │   ├── ui/               # shadcn-svelte base UI components
+    │   ├── canvas/           # PDF.js + Konva.js canvas editor
+    │   ├── panels/           # Side panels (attributes, categories, etc.)
+    │   ├── layout/           # Layout components
+    │   ├── settings/         # Settings components
+    │   └── common/           # Shared components
+    ├── stores/               # Svelte 5 Runes state management
+    ├── types/                # OmniDocBench type definitions
+    └── utils/                # Utility functions
+tests/                        # Vitest unit tests
 ```

--- a/saegim-frontend/src/lib/components/admin/AdminProjectsPanel.svelte
+++ b/saegim-frontend/src/lib/components/admin/AdminProjectsPanel.svelte
@@ -19,8 +19,8 @@
 
 <div class="space-y-4">
   <div>
-    <h3 class="text-foreground text-sm font-semibold">프로젝트 관리</h3>
-    <p class="text-muted-foreground text-xs">전체 프로젝트 현황을 확인하세요.</p>
+    <h3 class="text-foreground text-sm font-semibold">Project Admin</h3>
+    <p class="text-muted-foreground text-xs">View all project status.</p>
   </div>
 
   {#if projects.length > 0}
@@ -28,13 +28,13 @@
       <table class="w-full text-sm">
         <thead>
           <tr class="bg-muted/50 border-border border-b">
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">프로젝트</th>
-            <th class="text-muted-foreground px-4 py-2 text-center font-medium">멤버</th>
-            <th class="text-muted-foreground px-4 py-2 text-center font-medium">총 페이지</th>
-            <th class="text-muted-foreground px-4 py-2 text-center font-medium">완료</th>
-            <th class="text-muted-foreground px-4 py-2 text-center font-medium">검수 대기</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">진행률</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">생성일</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Project</th>
+            <th class="text-muted-foreground px-4 py-2 text-center font-medium">Member</th>
+            <th class="text-muted-foreground px-4 py-2 text-center font-medium">Total Pages</th>
+            <th class="text-muted-foreground px-4 py-2 text-center font-medium">Complete</th>
+            <th class="text-muted-foreground px-4 py-2 text-center font-medium">Review Pending</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Progress</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Created</th>
           </tr>
         </thead>
         <tbody>
@@ -70,7 +70,7 @@
     </div>
   {:else}
     <div class="border-border rounded-lg border border-dashed p-8 text-center">
-      <p class="text-muted-foreground text-sm">등록된 프로젝트가 없습니다.</p>
+      <p class="text-muted-foreground text-sm">No projects registered.</p>
     </div>
   {/if}
 </div>

--- a/saegim-frontend/src/lib/components/admin/AdminStatsPanel.svelte
+++ b/saegim-frontend/src/lib/components/admin/AdminStatsPanel.svelte
@@ -12,32 +12,32 @@
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
   <Card.Root>
     <Card.Header>
-      <Card.Description>총 사용자</Card.Description>
+      <Card.Description>Total Users</Card.Description>
       <Card.Title class="text-3xl">{stats.total_users}</Card.Title>
     </Card.Header>
     <Card.Content>
-      <p class="text-muted-foreground text-xs">활성 사용자: {stats.active_users}명</p>
+      <p class="text-muted-foreground text-xs">Active users: {stats.active_users}</p>
     </Card.Content>
   </Card.Root>
 
   <Card.Root>
     <Card.Header>
-      <Card.Description>총 프로젝트</Card.Description>
+      <Card.Description>Total Projects</Card.Description>
       <Card.Title class="text-3xl">{stats.total_projects}</Card.Title>
     </Card.Header>
     <Card.Content>
-      <p class="text-muted-foreground text-xs">총 페이지: {stats.total_pages}</p>
+      <p class="text-muted-foreground text-xs">Total Pages: {stats.total_pages}</p>
     </Card.Content>
   </Card.Root>
 
   <Card.Root>
     <Card.Header>
-      <Card.Description>전체 완료율</Card.Description>
+      <Card.Description>Overall Completion</Card.Description>
       <Card.Title class="text-3xl">{stats.completion_rate}%</Card.Title>
     </Card.Header>
     <Card.Content>
       <p class="text-muted-foreground text-xs">
-        완료: {stats.completed_pages} / 검수 대기: {stats.submitted_pages}
+        Complete: {stats.completed_pages} / Review Pending: {stats.submitted_pages}
       </p>
     </Card.Content>
   </Card.Root>

--- a/saegim-frontend/src/lib/components/admin/AdminUsersPanel.svelte
+++ b/saegim-frontend/src/lib/components/admin/AdminUsersPanel.svelte
@@ -11,9 +11,9 @@
   let { users, onrolechange, ontoggleactive }: Props = $props()
 
   const ROLE_LABELS: Record<UserRole, string> = {
-    admin: '관리자',
-    annotator: '주석자',
-    reviewer: '검수자',
+    admin: 'Admin',
+    annotator: 'Annotator',
+    reviewer: 'Reviewer',
   }
 
   const ROLE_COLORS: Record<UserRole, string> = {
@@ -35,8 +35,8 @@
 
 <div class="space-y-4">
   <div>
-    <h3 class="text-foreground text-sm font-semibold">사용자 관리</h3>
-    <p class="text-muted-foreground text-xs">시스템 사용자를 관리하고 역할을 변경하세요.</p>
+    <h3 class="text-foreground text-sm font-semibold">User Admin</h3>
+    <p class="text-muted-foreground text-xs">Manage system users and roles.</p>
   </div>
 
   {#if users.length > 0}
@@ -44,12 +44,12 @@
       <table class="w-full text-sm">
         <thead>
           <tr class="bg-muted/50 border-border border-b">
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">이름</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">로그인 ID</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">이메일</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">역할</th>
-            <th class="text-muted-foreground px-4 py-2 text-center font-medium">활성화</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">가입일</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Name</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Sign in ID</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Email</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Role</th>
+            <th class="text-muted-foreground px-4 py-2 text-center font-medium">Active</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Joined</th>
           </tr>
         </thead>
         <tbody>
@@ -92,7 +92,7 @@
     </div>
   {:else}
     <div class="border-border rounded-lg border border-dashed p-8 text-center">
-      <p class="text-muted-foreground text-sm">등록된 사용자가 없습니다.</p>
+      <p class="text-muted-foreground text-sm">No users registered.</p>
     </div>
   {/if}
 </div>

--- a/saegim-frontend/src/lib/components/canvas/HybridViewer.svelte
+++ b/saegim-frontend/src/lib/components/canvas/HybridViewer.svelte
@@ -365,7 +365,7 @@
         />
       </svg>
       <span class="text-xs font-medium text-blue-900 dark:text-blue-200">
-        이 영역에서 텍스트를 추출하시겠습니까?
+        Extract text from this area?
       </span>
       {#if showEngineSelector}
         <select
@@ -382,13 +382,13 @@
         class="rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-blue-700"
         onclick={handleOcrRequest}
       >
-        OCR 실행
+        Run OCR
       </button>
       <button
         type="button"
         class="text-muted-foreground hover:text-foreground px-1 text-lg leading-none"
         onclick={dismissOcrPrompt}
-        aria-label="닫기"
+        aria-label="Close"
       >
         &times;
       </button>

--- a/saegim-frontend/src/lib/components/canvas/TextOverlay.svelte
+++ b/saegim-frontend/src/lib/components/canvas/TextOverlay.svelte
@@ -137,14 +137,14 @@
           shadow-lg transition-colors"
         onclick={handleCreateBbox}
       >
-        새 bbox 생성
+        Create New bbox
       </button>
       <button
         class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 shadow-lg
           transition-colors hover:bg-gray-200"
         onclick={dismissCreateBbox}
       >
-        취소
+        Cancel
       </button>
     </div>
   {/if}

--- a/saegim-frontend/src/lib/components/common/Select.svelte
+++ b/saegim-frontend/src/lib/components/common/Select.svelte
@@ -29,7 +29,7 @@
     {disabled}
     onchange={handleChange}
   >
-    <option value="">-- 선택 --</option>
+    <option value="">-- Select --</option>
     {#each options as opt (opt)}
       <option value={opt}>{labels?.[opt] ?? opt}</option>
     {/each}

--- a/saegim-frontend/src/lib/components/layout/AuthHero.svelte
+++ b/saegim-frontend/src/lib/components/layout/AuthHero.svelte
@@ -3,7 +3,7 @@
 >
   <div class="max-w-lg">
     <h1 class="text-foreground text-4xl font-bold tracking-tight">saegim</h1>
-    <p class="text-muted-foreground mt-2 text-lg">문서 레이블링 플랫폼</p>
+    <p class="text-muted-foreground mt-2 text-lg">Document Labeling Platform</p>
 
     <div class="mt-10 space-y-6">
       <div class="flex items-start gap-4">
@@ -25,9 +25,9 @@
           </svg>
         </div>
         <div>
-          <h3 class="text-foreground font-semibold">문서 업로드 & OCR</h3>
+          <h3 class="text-foreground font-semibold">Document Upload & OCR</h3>
           <p class="text-muted-foreground mt-1 text-sm">
-            PDF, 이미지 등 다양한 문서를 업로드하고 AI 기반 OCR로 텍스트를 자동 추출합니다.
+            Upload PDFs, images, and other documents, then extract text with AI-powered OCR.
           </p>
         </div>
       </div>
@@ -52,9 +52,9 @@
           </svg>
         </div>
         <div>
-          <h3 class="text-foreground font-semibold">체계적 레이블링</h3>
+          <h3 class="text-foreground font-semibold">Structured Labeling</h3>
           <p class="text-muted-foreground mt-1 text-sm">
-            팀원과 함께 문서 요소를 분류하고 레이블을 부여하여 데이터를 체계적으로 관리합니다.
+            Classify document elements with your team and keep labeling data organized.
           </p>
         </div>
       </div>
@@ -78,9 +78,9 @@
           </svg>
         </div>
         <div>
-          <h3 class="text-foreground font-semibold">팀 협업</h3>
+          <h3 class="text-foreground font-semibold">Team Collaboration</h3>
           <p class="text-muted-foreground mt-1 text-sm">
-            팀원과 역할을 관리하고, 작업을 할당하여 효율적으로 협업합니다.
+            Manage team members and roles, assign tasks, and collaborate efficiently.
           </p>
         </div>
       </div>

--- a/saegim-frontend/src/lib/components/layout/Header.svelte
+++ b/saegim-frontend/src/lib/components/layout/Header.svelte
@@ -62,7 +62,7 @@
     {#if showAutoSave}
       <div class="flex items-center gap-2">
         <label class="flex cursor-pointer items-center gap-1.5">
-          <span class="text-xs font-medium text-white/70">자동 저장</span>
+          <span class="text-xs font-medium text-white/70">Auto-save</span>
           <Switch
             checked={autosaveStore.enabled}
             onCheckedChange={(checked) => autosaveStore.setEnabled(checked)}
@@ -82,7 +82,7 @@
       <span
         class="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300"
       >
-        저장되지 않은 변경
+        Unsaved changes
       </span>
     {/if}
 
@@ -96,7 +96,7 @@
           disabled={reverting || !annotationStore.isDirty}
           onclick={onrevert}
         >
-          {reverting ? '되돌리는 중...' : '마지막 저장으로 되돌리기'}
+          {reverting ? 'Reverting...' : 'Revert to Last Save'}
         </button>
       {/if}
 
@@ -108,7 +108,7 @@
         disabled={saving || !annotationStore.isDirty}
         onclick={onsave}
       >
-        {saving ? '저장 중...' : '저장'}
+        {saving ? 'Saving...' : 'Save'}
       </button>
     {/if}
 
@@ -122,7 +122,7 @@
         class="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
       >
         <User class="size-4" />
-        <span>계정</span>
+        <span>Account</span>
       </a>
     {/if}
 
@@ -132,7 +132,7 @@
         class="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
       >
         <ClipboardList class="size-4" />
-        <span>내 작업</span>
+        <span>My Tasks</span>
       </a>
     {/if}
 
@@ -142,7 +142,7 @@
         class="flex items-center gap-1 rounded-lg px-2 py-1.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
       >
         <Shield class="size-4" />
-        <span>관리</span>
+        <span>Admin</span>
       </a>
     {/if}
 
@@ -154,7 +154,7 @@
         onclick={handleLogout}
       >
         <LogOut class="size-4" />
-        <span>로그아웃</span>
+        <span>Sign out</span>
       </button>
     {/if}
   </div>

--- a/saegim-frontend/src/lib/components/layout/ShortcutHelp.svelte
+++ b/saegim-frontend/src/lib/components/layout/ShortcutHelp.svelte
@@ -16,37 +16,37 @@
 
   const shortcutGroups = [
     {
-      label: '도구',
+      label: 'Tools',
       items: [
-        { key: '1', description: '선택' },
-        { key: '2', description: '그리기' },
-        { key: '3', description: '이동' },
+        { key: '1', description: 'Select' },
+        { key: '2', description: 'Draw' },
+        { key: '3', description: 'Pan' },
       ],
     },
     {
-      label: '편집',
+      label: 'Edit',
       items: [
-        { key: `${modKey}+S`, description: '저장' },
-        { key: `${modKey}+Z`, description: '실행 취소' },
-        { key: `${modKey}+Shift+Z`, description: '다시 실행' },
-        { key: 'X', description: '선택 요소 삭제' },
+        { key: `${modKey}+S`, description: 'Save' },
+        { key: `${modKey}+Z`, description: 'Undo' },
+        { key: `${modKey}+Shift+Z`, description: 'Redo' },
+        { key: 'X', description: 'Select Element Delete' },
       ],
     },
     {
-      label: '보기',
-      items: [{ key: 'R', description: '읽기 순서 토글' }],
+      label: 'View',
+      items: [{ key: 'R', description: 'Toggle Reading Order' }],
     },
     {
-      label: '탐색',
+      label: 'Navigation',
       items: [
-        { key: 'Q', description: '이전 페이지' },
-        { key: 'E', description: '다음 페이지' },
-        { key: 'Esc', description: '선택 해제' },
+        { key: 'Q', description: 'Previous Page' },
+        { key: 'E', description: 'Next Page' },
+        { key: 'Esc', description: 'Clear Selection' },
       ],
     },
     {
-      label: '도움말',
-      items: [{ key: '`', description: '이 도움말' }],
+      label: 'Help',
+      items: [{ key: '`', description: 'This Help' }],
     },
   ] as const
 </script>
@@ -61,12 +61,12 @@
         class="text-white/80 hover:bg-white/10 hover:text-white"
       >
         <Keyboard class="size-4" />
-        <span class="sr-only">키보드 단축키</span>
+        <span class="sr-only">Keyboard Shortcuts</span>
       </Button>
     {/snippet}
   </Popover.Trigger>
   <Popover.Content side="bottom" align="end" class="w-64 p-3">
-    <div class="mb-2 text-sm font-semibold">키보드 단축키</div>
+    <div class="mb-2 text-sm font-semibold">Keyboard Shortcuts</div>
     <div class="space-y-3">
       {#each shortcutGroups as group}
         <div>

--- a/saegim-frontend/src/lib/components/layout/Sidebar.svelte
+++ b/saegim-frontend/src/lib/components/layout/Sidebar.svelte
@@ -7,10 +7,10 @@
   import RelationPanel from '$lib/components/panels/RelationPanel.svelte'
 
   const tabs: { key: PanelTab; label: string }[] = [
-    { key: 'elements', label: '요소' },
-    { key: 'attributes', label: '속성' },
-    { key: 'text', label: '텍스트' },
-    { key: 'relations', label: '관계' },
+    { key: 'elements', label: 'Element' },
+    { key: 'attributes', label: 'Attributes' },
+    { key: 'text', label: 'Text' },
+    { key: 'relations', label: 'Relations' },
   ]
 </script>
 

--- a/saegim-frontend/src/lib/components/layout/ThemeToggle.svelte
+++ b/saegim-frontend/src/lib/components/layout/ThemeToggle.svelte
@@ -13,5 +13,5 @@
 >
   <Sun class="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
   <Moon class="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-  <span class="sr-only">테마 전환</span>
+  <span class="sr-only">Toggle Theme</span>
 </Button>

--- a/saegim-frontend/src/lib/components/panels/AttributePanel.svelte
+++ b/saegim-frontend/src/lib/components/panels/AttributePanel.svelte
@@ -30,21 +30,21 @@
   <div class="space-y-4 p-3">
     <div class="flex items-center justify-between">
       <h3 class="text-foreground text-sm font-semibold">
-        요소 #{element.anno_id}
+        Element #{element.anno_id}
       </h3>
-      <span class="text-muted-foreground text-xs">순서: {element.order}</span>
+      <span class="text-muted-foreground text-xs">Order: {element.order}</span>
     </div>
 
     <CategorySelect value={element.category_type} onchange={handleCategoryChange} />
 
     <div class="flex items-center gap-2">
       <Switch checked={element.ignore} onCheckedChange={handleToggleIgnore} />
-      <Label class="text-sm">무시 처리</Label>
+      <Label class="text-sm">Ignore</Label>
     </div>
 
     {#if fields.length > 0}
       <div class="border-border space-y-3 border-t pt-3">
-        <h4 class="text-muted-foreground text-xs font-medium uppercase">속성</h4>
+        <h4 class="text-muted-foreground text-xs font-medium uppercase">Attributes</h4>
         {#each fields as field (field.key)}
           {#if field.type === 'select' && field.options}
             <Select
@@ -69,6 +69,6 @@
   </div>
 {:else}
   <div class="p-3 text-center">
-    <p class="text-muted-foreground py-8 text-sm">요소를 선택하세요.</p>
+    <p class="text-muted-foreground py-8 text-sm">Select an element.</p>
   </div>
 {/if}

--- a/saegim-frontend/src/lib/components/panels/CategorySelect.svelte
+++ b/saegim-frontend/src/lib/components/panels/CategorySelect.svelte
@@ -12,7 +12,7 @@
 
 <div>
   <label class="text-muted-foreground mb-1 block text-xs font-medium" for="category-select"
-    >카테고리</label
+    >Category</label
   >
   <select
     id="category-select"

--- a/saegim-frontend/src/lib/components/panels/ElementList.svelte
+++ b/saegim-frontend/src/lib/components/panels/ElementList.svelte
@@ -45,7 +45,7 @@
       await updateReadingOrder(pageId, apiOrderMap)
       annotationStore.markSaved()
     } catch {
-      uiStore.showNotification('순서 저장에 실패했습니다', 'error')
+      uiStore.showNotification('Failed to save order', 'error')
     }
   }
 
@@ -131,42 +131,42 @@
 
 <div class="border-border bg-muted flex items-center justify-between border-b p-3">
   <div>
-    <h3 class="text-foreground text-sm font-semibold">요소 목록</h3>
+    <h3 class="text-foreground text-sm font-semibold">Element List</h3>
     <p class="text-muted-foreground mt-0.5 text-xs">
-      {annotationStore.elements.length}개 요소
+      {annotationStore.elements.length} elements
     </p>
   </div>
   <div class="flex items-center gap-3">
-    <label class="flex cursor-pointer items-center gap-1.5" title="요소 표시 (I)">
+    <label class="flex cursor-pointer items-center gap-1.5" title="Show Elements (I)">
       <input
         type="checkbox"
         class="accent-primary h-3.5 w-3.5 rounded"
         checked={canvasStore.showElementIndex}
         onchange={() => canvasStore.toggleElementIndex()}
       />
-      <span class="text-muted-foreground text-xs">요소</span>
+      <span class="text-muted-foreground text-xs">Element</span>
     </label>
-    <label class="flex cursor-pointer items-center gap-1.5" title="순서 표시 (R)">
+    <label class="flex cursor-pointer items-center gap-1.5" title="Show Order (R)">
       <input
         type="checkbox"
         class="accent-primary h-3.5 w-3.5 rounded"
         checked={canvasStore.showReadingOrder}
         onchange={() => canvasStore.toggleReadingOrder()}
       />
-      <span class="text-muted-foreground text-xs">순서</span>
+      <span class="text-muted-foreground text-xs">Order</span>
     </label>
   </div>
 </div>
 
 {#if selectedCount > 0}
   <div class="border-border bg-card flex items-center gap-1.5 border-b px-2 py-2">
-    <span class="text-foreground mr-1 text-xs font-medium">{selectedCount}개 선택</span>
+    <span class="text-foreground mr-1 text-xs font-medium">{selectedCount} selected</span>
     <button
       type="button"
       class="text-muted-foreground hover:bg-accent hover:text-foreground rounded px-1.5 py-1 text-xs"
       onclick={() => handleMoveSelected(-1)}
-      title="선택 요소 위로 이동"
-      aria-label="선택 요소 위로 이동"
+      title="Move selected element up"
+      aria-label="Move selected element up"
     >
       ↑
     </button>
@@ -174,8 +174,8 @@
       type="button"
       class="text-muted-foreground hover:bg-accent hover:text-foreground rounded px-1.5 py-1 text-xs"
       onclick={() => handleMoveSelected(1)}
-      title="선택 요소 아래로 이동"
-      aria-label="선택 요소 아래로 이동"
+      title="Move selected element down"
+      aria-label="Move selected element down"
     >
       ↓
     </button>
@@ -183,19 +183,19 @@
       type="button"
       class="text-destructive/80 hover:bg-destructive/10 rounded px-1.5 py-1 text-xs"
       onclick={handleDeleteSelected}
-      title="선택 요소 삭제"
-      aria-label="선택 요소 삭제"
+      title="Delete selected elements"
+      aria-label="Delete selected elements"
     >
-      삭제
+      Delete
     </button>
     <button
       type="button"
       class="text-muted-foreground hover:bg-accent hover:text-foreground ml-auto rounded px-1.5 py-1 text-xs"
       onclick={() => annotationStore.clearSelection()}
-      title="선택 해제"
-      aria-label="선택 해제"
+      title="Clear Selection"
+      aria-label="Clear Selection"
     >
-      해제
+      Clear
     </button>
   </div>
 {/if}
@@ -243,13 +243,13 @@
         <span class="text-muted-foreground mr-0.5 font-medium">{element.order}.</span>
         {getLabel(element.category_type)}
         {#if element.ignore}
-          <span class="text-muted-foreground text-xs italic">(무시)</span>
+          <span class="text-muted-foreground text-xs italic">(Ignore)</span>
         {/if}
       </span>
       <button
         class="text-muted-foreground hover:text-destructive px-1 opacity-0 transition-all group-hover:opacity-100"
         onclick={(e) => handleDelete(e, element.anno_id)}
-        aria-label="삭제"
+        aria-label="Delete"
       >
         &times;
       </button>
@@ -257,7 +257,7 @@
   {/each}
   {#if annotationStore.elements.length === 0}
     <p class="text-muted-foreground py-8 text-center text-xs">
-      요소가 없습니다.<br />그리기 도구로 추가하세요.
+      No elements yet.<br />Add one with the draw tool.
     </p>
   {/if}
 </div>

--- a/saegim-frontend/src/lib/components/panels/ExtractionPreview.svelte
+++ b/saegim-frontend/src/lib/components/panels/ExtractionPreview.svelte
@@ -101,9 +101,9 @@
       const response = await acceptExtraction(pageId)
       onAccepted(response.annotation_data as AnnotationData)
       dismissed = true
-      uiStore.showNotification('자동 추출 결과가 반영되었습니다', 'success')
+      uiStore.showNotification('Automatic extraction results applied', 'success')
     } catch {
-      uiStore.showNotification('자동 추출 수락에 실패했습니다', 'error')
+      uiStore.showNotification('Failed to accept automatic extraction', 'error')
     } finally {
       loading = false
     }
@@ -115,9 +115,12 @@
       const response = await forceAcceptExtraction(pageId)
       onAccepted(response.annotation_data as AnnotationData)
       dismissed = true
-      uiStore.showNotification('자동 추출 결과가 반영되었습니다 (기존 주석 대체)', 'success')
+      uiStore.showNotification(
+        'Automatic extraction results applied (existing annotations replaced)',
+        'success',
+      )
     } catch {
-      uiStore.showNotification('자동 추출 수락에 실패했습니다', 'error')
+      uiStore.showNotification('Failed to accept automatic extraction', 'error')
     } finally {
       loading = false
     }
@@ -143,7 +146,7 @@
           d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182M2.985 19.644l3.181-3.183"
         />
       </svg>
-      전체 재스캔
+      Rescan All
     </button>
   </div>
 {/if}
@@ -166,9 +169,9 @@
         />
       </svg>
       <div>
-        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">OCR 추출 진행 중...</p>
+        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">OCR extraction in progress...</p>
         <p class="mt-0.5 text-xs text-amber-700 dark:text-amber-300">
-          구조 분석이 완료되면 자동으로 결과가 표시됩니다.
+          Results will appear automatically after structure analysis completes.
         </p>
       </div>
     </div>
@@ -190,19 +193,19 @@
         />
       </svg>
       <div>
-        <p class="text-muted-foreground text-xs">자동 추출 결과가 없습니다.</p>
+        <p class="text-muted-foreground text-xs">No automatic extraction results.</p>
         <p class="text-muted-foreground mt-0.5 text-xs">
-          그리기 도구로 직접 영역을 추가하거나, <a
+          Add regions manually with the draw tool, or <a
             href="/settings"
-            class="text-primary hover:underline">OCR 설정</a
-          >을 확인하세요.
+            class="text-primary hover:underline">OCR Settings</a
+          >.
         </p>
       </div>
       <button
         type="button"
         class="text-muted-foreground hover:text-foreground shrink-0 p-0.5 text-lg leading-none"
         onclick={handleDismiss}
-        aria-label="닫기"
+        aria-label="Close"
       >
         &times;
       </button>
@@ -215,17 +218,17 @@
     <div class="flex items-start justify-between gap-2">
       <div class="min-w-0 flex-1">
         <p class="text-sm font-medium text-blue-900 dark:text-blue-200">
-          자동 추출 결과가 있습니다
+          Automatic extraction results available
         </p>
         <p class="mt-1 text-xs text-blue-700 dark:text-blue-300">
-          텍스트 {textCount}개, 이미지 {imageCount}개 — 총 {totalCount}개 요소
+          Text {textCount}, images {imageCount} - total {totalCount} elements
         </p>
       </div>
       <button
         type="button"
         class="p-0.5 text-lg leading-none text-blue-400 hover:text-blue-600 dark:text-blue-500 dark:hover:text-blue-400"
         onclick={handleDismiss}
-        aria-label="닫기"
+        aria-label="Close"
       >
         &times;
       </button>
@@ -240,7 +243,7 @@
         onclick={handleAccept}
         disabled={loading}
       >
-        {loading ? '반영 중...' : '수락'}
+        {loading ? 'Applying...' : 'Accept'}
       </button>
       <button
         type="button"
@@ -249,7 +252,7 @@
           font-medium transition-colors"
         onclick={handleDismiss}
       >
-        무시
+        Ignore
       </button>
     </div>
   </div>
@@ -260,20 +263,20 @@
     <div class="flex items-start justify-between gap-2">
       <div class="min-w-0 flex-1">
         <p class="text-sm font-medium text-violet-900 dark:text-violet-200">
-          새로운 추출 결과가 있습니다
+          New extraction results available
         </p>
         <p class="mt-1 text-xs text-violet-700 dark:text-violet-300">
-          텍스트 {textCount}개, 이미지 {imageCount}개 — 총 {totalCount}개 요소
+          Text {textCount}, images {imageCount} - total {totalCount} elements
         </p>
         <p class="mt-1 text-xs font-medium text-violet-600 dark:text-violet-400">
-          수락하면 기존 주석이 대체됩니다.
+          Accepting will replace existing annotations.
         </p>
       </div>
       <button
         type="button"
         class="p-0.5 text-lg leading-none text-violet-400 hover:text-violet-600 dark:text-violet-500 dark:hover:text-violet-400"
         onclick={handleDismiss}
-        aria-label="닫기"
+        aria-label="Close"
       >
         &times;
       </button>
@@ -288,7 +291,7 @@
         onclick={handleForceAccept}
         disabled={loading}
       >
-        {loading ? '반영 중...' : '수락 (대체)'}
+        {loading ? 'Applying...' : 'Accept (Replace)'}
       </button>
       <button
         type="button"
@@ -297,7 +300,7 @@
           font-medium transition-colors"
         onclick={handleDismiss}
       >
-        무시
+        Ignore
       </button>
     </div>
   </div>

--- a/saegim-frontend/src/lib/components/panels/PageAttributePanel.svelte
+++ b/saegim-frontend/src/lib/components/panels/PageAttributePanel.svelte
@@ -17,10 +17,10 @@
 
 {#if attr}
   <div class="space-y-4 p-3">
-    <h3 class="text-foreground text-sm font-semibold">페이지 속성</h3>
+    <h3 class="text-foreground text-sm font-semibold">Page Attributes</h3>
 
     <Select
-      label="데이터 출처"
+      label="Data Source"
       value={attr.data_source ?? ''}
       options={DATA_SOURCES}
       labels={DATA_SOURCE_LABELS}
@@ -28,7 +28,7 @@
     />
 
     <Select
-      label="언어"
+      label="Language"
       value={attr.language ?? ''}
       options={PAGE_LANGUAGES}
       labels={PAGE_LANGUAGE_LABELS}
@@ -36,7 +36,7 @@
     />
 
     <Select
-      label="레이아웃"
+      label="Layout"
       value={attr.layout ?? ''}
       options={PAGE_LAYOUTS}
       labels={PAGE_LAYOUT_LABELS}
@@ -44,7 +44,7 @@
     />
 
     <div class="border-border space-y-3 border-t pt-3">
-      <h4 class="text-muted-foreground text-xs font-medium uppercase">특수 속성</h4>
+      <h4 class="text-muted-foreground text-xs font-medium uppercase">Special Attributes</h4>
       <div class="flex items-center gap-2">
         <Switch
           checked={attr.watermark ?? false}
@@ -53,7 +53,7 @@
               watermark: !(attr?.watermark ?? false),
             })}
         />
-        <Label class="text-sm">워터마크</Label>
+        <Label class="text-sm">Watermark</Label>
       </div>
       <div class="flex items-center gap-2">
         <Switch
@@ -63,7 +63,7 @@
               fuzzy_scan: !(attr?.fuzzy_scan ?? false),
             })}
         />
-        <Label class="text-sm">흐린 스캔</Label>
+        <Label class="text-sm">Blurry Scan</Label>
       </div>
       <div class="flex items-center gap-2">
         <Switch
@@ -73,12 +73,12 @@
               colorful_background: !(attr?.colorful_background ?? false),
             })}
         />
-        <Label class="text-sm">컬러 배경</Label>
+        <Label class="text-sm">Color Background</Label>
       </div>
     </div>
   </div>
 {:else}
   <div class="p-3 text-center">
-    <p class="text-muted-foreground py-8 text-sm">페이지 데이터를 불러오는 중...</p>
+    <p class="text-muted-foreground py-8 text-sm">Loading page data...</p>
   </div>
 {/if}

--- a/saegim-frontend/src/lib/components/panels/PageNavigator.svelte
+++ b/saegim-frontend/src/lib/components/panels/PageNavigator.svelte
@@ -47,7 +47,7 @@
     <button
       class="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs font-medium tracking-wider uppercase transition-colors"
       onclick={() => (expanded = !expanded)}
-      title={expanded ? '페이지 목록 접기' : '페이지 목록 펼치기'}
+      title={expanded ? 'Collapse Page List' : 'Expand Page List'}
     >
       <svg
         class="h-3 w-3 transition-transform {expanded ? 'rotate-90' : ''}"
@@ -58,14 +58,14 @@
       >
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
       </svg>
-      페이지
+      Page
     </button>
     <div class="flex items-center gap-1">
       <button
         class="text-muted-foreground hover:text-foreground hover:bg-accent rounded p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-30"
         disabled={!hasPrev}
         onclick={prevPage}
-        title="이전 페이지 (Q)"
+        title="Previous Page (Q)"
       >
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
@@ -78,7 +78,7 @@
         class="text-muted-foreground hover:text-foreground hover:bg-accent rounded p-1 transition-colors disabled:cursor-not-allowed disabled:opacity-30"
         disabled={!hasNext}
         onclick={nextPage}
-        title="다음 페이지 (E)"
+        title="Next Page (E)"
       >
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
@@ -97,7 +97,7 @@
               ? 'bg-primary text-primary-foreground font-medium shadow-sm'
               : 'bg-card border-border text-foreground hover:border-primary/30 hover:bg-primary/10 border'}"
             onclick={() => goToPage(page.id)}
-            title="페이지 {page.page_no} ({page.status})"
+            title="Page {page.page_no} ({page.status})"
           >
             {page.page_no}
           </button>
@@ -112,12 +112,12 @@
           {#if count > 0}
             <span class="rounded-full px-1.5 py-0.5 text-[10px] {statusColors[status]}">
               {status === 'in_progress'
-                ? '진행중'
+                ? 'In Progress'
                 : status === 'pending'
-                  ? '대기'
+                  ? 'Pending'
                   : status === 'submitted'
-                    ? '제출'
-                    : '검토완료'}
+                    ? 'Submit'
+                    : 'Reviewed'}
               {count}
             </span>
           {/if}

--- a/saegim-frontend/src/lib/components/panels/RelationPanel.svelte
+++ b/saegim-frontend/src/lib/components/panels/RelationPanel.svelte
@@ -6,7 +6,7 @@
   import type { Relation } from '$lib/types/omnidocbench'
 
   const RELATION_TYPES = [
-    { value: 'parent_son', label: '부모-자식' },
+    { value: 'parent_son', label: 'Parent-Child' },
     { value: 'figure_caption', label: 'Figure ↔ Caption' },
     { value: 'table_caption', label: 'Table ↔ Caption' },
     { value: 'table_footnote', label: 'Table ↔ Footnote' },
@@ -54,12 +54,12 @@
 
     annotationStore.addRelation(selectedElement.anno_id, targetAnnoId, selectedRelationType)
     isSelectingTarget = false
-    uiStore.showNotification('관계가 추가되었습니다', 'success')
+    uiStore.showNotification('Relation added', 'success')
   }
 
   function handleRemoveRelation(relation: Relation): void {
     annotationStore.removeRelation(relation.source_anno_id, relation.target_anno_id)
-    uiStore.showNotification('관계가 삭제되었습니다', 'success')
+    uiStore.showNotification('Relation deleted', 'success')
   }
 
   function getRelationTypeLabel(type: string): string {
@@ -75,11 +75,11 @@
 
 {#if selectedElement}
   <div class="space-y-3 p-3">
-    <h3 class="text-foreground text-sm font-semibold">관계 편집</h3>
+    <h3 class="text-foreground text-sm font-semibold">Relations Edit</h3>
 
     <!-- Current element info -->
     <div class="bg-muted rounded-md px-2.5 py-1.5 text-xs">
-      <span class="text-muted-foreground">선택된 요소:</span>
+      <span class="text-muted-foreground">Selected Element:</span>
       <span class="text-foreground font-medium">
         #{selectedElement.anno_id} {selectedElement.category_type}
       </span>
@@ -88,7 +88,7 @@
     <!-- Existing relations -->
     {#if elementRelations.length > 0}
       <div class="space-y-1">
-        <p class="text-muted-foreground text-xs font-medium">연결된 관계 ({elementRelations.length})</p>
+        <p class="text-muted-foreground text-xs font-medium">Linked Relations ({elementRelations.length})</p>
         {#each elementRelations as relation}
           {@const sourceId = relation.source_anno_id}
           {@const targetId = relation.target_anno_id}
@@ -128,7 +128,7 @@
             <button
               class="text-muted-foreground hover:text-destructive shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
               onclick={() => handleRemoveRelation(relation)}
-              aria-label="관계 삭제"
+              aria-label="Relations Delete"
             >
               <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -163,19 +163,19 @@
         {/each}
       </div>
     {:else}
-      <p class="text-muted-foreground text-xs">이 요소에 연결된 관계가 없습니다.</p>
+      <p class="text-muted-foreground text-xs">No relations linked to this element.</p>
     {/if}
 
     <!-- Add relation -->
     {#if isSelectingTarget}
       <div class="space-y-2">
         <div class="flex items-center justify-between">
-          <p class="text-foreground text-xs font-medium">대상 요소 선택</p>
+          <p class="text-foreground text-xs font-medium">Select Target Element</p>
           <button
             class="text-muted-foreground hover:text-foreground text-xs"
             onclick={cancelSelectTarget}
           >
-            취소
+            Cancel
           </button>
         </div>
 
@@ -217,12 +217,12 @@
         class="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
         onclick={startSelectTarget}
       >
-        + 관계 추가
+        + Relations Add
       </button>
     {/if}
   </div>
 {:else}
   <div class="p-3 text-center">
-    <p class="text-muted-foreground py-8 text-sm">요소를 선택하면 관계를 편집할 수 있습니다.</p>
+    <p class="text-muted-foreground py-8 text-sm">Select an element to edit relations.</p>
   </div>
 {/if}

--- a/saegim-frontend/src/lib/components/panels/TextEditor.svelte
+++ b/saegim-frontend/src/lib/components/panels/TextEditor.svelte
@@ -29,7 +29,7 @@
 
 {#if element}
   <div class="space-y-3 p-3">
-    <h3 class="text-foreground text-sm font-semibold">텍스트 편집</h3>
+    <h3 class="text-foreground text-sm font-semibold">Text Edit</h3>
 
     <div class="border-border flex border-b">
       {#each tabs as tab (tab.key)}
@@ -51,14 +51,14 @@
       value={currentValue}
       oninput={handleTextChange}
       placeholder={activeTab === 'text'
-        ? '텍스트 내용을 입력하세요...'
+        ? 'Enter text content...'
         : activeTab === 'latex'
-          ? 'LaTeX 수식을 입력하세요...'
-          : 'HTML 내용을 입력하세요...'}
+          ? 'Enter a LaTeX formula...'
+          : 'Enter HTML content...'}
     ></textarea>
   </div>
 {:else}
   <div class="p-3 text-center">
-    <p class="text-muted-foreground py-8 text-sm">요소를 선택하면 텍스트를 편집할 수 있습니다.</p>
+    <p class="text-muted-foreground py-8 text-sm">Select an element to edit text.</p>
   </div>
 {/if}

--- a/saegim-frontend/src/lib/components/settings/AddMemberDialog.svelte
+++ b/saegim-frontend/src/lib/components/settings/AddMemberDialog.svelte
@@ -49,22 +49,22 @@
 <Dialog.Root bind:open onOpenChange={handleOpenChange}>
   <Dialog.Content class="sm:max-w-md">
     <Dialog.Header>
-      <Dialog.Title>멤버 추가</Dialog.Title>
-      <Dialog.Description>프로젝트에 추가할 사용자를 선택하세요.</Dialog.Description>
+      <Dialog.Title>Add Member</Dialog.Title>
+      <Dialog.Description>Select a user to add to the project.</Dialog.Description>
     </Dialog.Header>
 
     <div class="space-y-4">
       <!-- Search -->
       <div>
         <label class="text-muted-foreground mb-1 block text-xs font-medium" for="member-search">
-          사용자 검색
+          Search Users
         </label>
         <input
           id="member-search"
           type="text"
           class="border-input bg-background text-foreground focus:border-ring focus:ring-ring
             block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
-          placeholder="이름 또는 이메일로 검색..."
+          placeholder="Search by name or email..."
           bind:value={searchQuery}
         />
       </div>
@@ -105,7 +105,7 @@
           {/each}
         {:else}
           <div class="text-muted-foreground p-4 text-center text-sm">
-            {searchQuery.trim() ? '검색 결과가 없습니다.' : '추가할 수 있는 사용자가 없습니다.'}
+            {searchQuery.trim() ? 'No search results.' : 'No users available to add.'}
           </div>
         {/if}
       </div>
@@ -113,7 +113,7 @@
       <!-- Role Selection -->
       <div>
         <label class="text-muted-foreground mb-1 block text-xs font-medium" for="member-role">
-          역할
+          Role
         </label>
         <select
           id="member-role"
@@ -127,8 +127,8 @@
       </div>
 
       <Dialog.Footer>
-        <Button variant="outline" onclick={() => handleOpenChange(false)}>취소</Button>
-        <Button variant="default" disabled={!isValid} onclick={handleAdd}>추가</Button>
+        <Button variant="outline" onclick={() => handleOpenChange(false)}>Cancel</Button>
+        <Button variant="default" disabled={!isValid} onclick={handleAdd}>Add</Button>
       </Dialog.Footer>
     </div>
   </Dialog.Content>

--- a/saegim-frontend/src/lib/components/settings/EngineAddDialog.svelte
+++ b/saegim-frontend/src/lib/components/settings/EngineAddDialog.svelte
@@ -40,12 +40,12 @@
     {
       value: 'vllm',
       label: 'vLLM',
-      description: 'vLLM 호환 서버',
+      description: 'vLLM-compatible server',
     },
     {
       value: 'split_pipeline',
-      label: '레이아웃 + OCR',
-      description: '레이아웃 감지 + OCR 파이프라인',
+      label: 'Layout + OCR',
+      description: 'Layout detection + OCR pipeline',
     },
   ]
 
@@ -75,7 +75,7 @@
     // Pre-fill name based on type
     if (t === 'commercial_api') name = 'Gemini Flash'
     else if (t === 'vllm') name = 'vLLM'
-    else if (t === 'split_pipeline') name = '레이아웃 + OCR'
+    else if (t === 'split_pipeline') name = 'Layout + OCR'
     // Pre-fill API key from env if available
     if (t === 'commercial_api' && envGeminiApiKey) {
       caApiKey = envGeminiApiKey
@@ -134,12 +134,12 @@
   <Dialog.Content class="sm:max-w-lg">
     <Dialog.Header>
       <Dialog.Title>
-        {step === 'type' ? '엔진 타입 선택' : '엔진 설정'}
+        {step === 'type' ? 'Select Engine Type' : 'Engine Settings'}
       </Dialog.Title>
       <Dialog.Description>
         {step === 'type'
-          ? '등록할 OCR 엔진 타입을 선택하세요.'
-          : `${ENGINE_OPTIONS.find((e) => e.value === engineType)?.label} 엔진의 이름과 설정을 입력하세요.`}
+          ? 'Select the OCR engine type to register.'
+          : `Enter the name and settings for the ${ENGINE_OPTIONS.find((e) => e.value === engineType)?.label} engine.`}
       </Dialog.Description>
     </Dialog.Header>
 
@@ -161,13 +161,13 @@
         <!-- Name -->
         <div>
           <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-name">
-            이름
+            Name
           </label>
           <input
             id="add-name"
             type="text"
             class="border-input bg-background text-foreground focus:border-ring focus:ring-ring block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
-            placeholder="표시될 이름"
+            placeholder="Display name"
             bind:value={name}
           />
         </div>
@@ -187,7 +187,7 @@
           </div>
           <div>
             <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-model">
-              모델
+              Model
             </label>
             <select
               id="add-model"
@@ -200,13 +200,13 @@
           </div>
           <div>
             <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-prompt">
-              OCR 프롬프트 (선택)
+              OCR Prompt (Optional)
             </label>
             <textarea
               id="add-prompt"
               class="border-input bg-background text-foreground focus:border-ring focus:ring-ring block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
               rows="4"
-              placeholder={"비워두면 기본 레이아웃 분석 프롬프트를 사용합니다. {width}와 {height}로 이미지 크기를 참조할 수 있습니다."}
+              placeholder={"Leave empty to use the default layout analysis prompt. Use {width} and {height} to reference image dimensions."}
               bind:value={caPrompt}
             ></textarea>
           </div>
@@ -216,7 +216,7 @@
           <div class="grid grid-cols-3 gap-3">
             <div class="col-span-2">
               <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-host">
-                호스트
+                Host
               </label>
               <input
                 id="add-host"
@@ -228,7 +228,7 @@
             </div>
             <div>
               <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-port">
-                포트
+                Port
               </label>
               <input
                 id="add-port"
@@ -241,7 +241,7 @@
           </div>
           <div>
             <label class="text-muted-foreground mb-1 block text-xs font-medium" for="add-vllm-model">
-              모델
+              Model
             </label>
             <input
               id="add-vllm-model"
@@ -259,7 +259,7 @@
               class="text-muted-foreground mb-1 block text-xs font-medium"
               for="add-layout-provider"
             >
-              레이아웃 감지기
+              Layout Detector
             </label>
             <select
               id="add-layout-provider"
@@ -276,7 +276,7 @@
                 class="text-muted-foreground mb-1 block text-xs font-medium"
                 for="add-docling"
               >
-                Docling 모델
+                Docling Model
               </label>
               <input
                 id="add-docling"
@@ -306,8 +306,8 @@
         {/if}
 
         <Dialog.Footer>
-          <Button variant="outline" onclick={() => (step = 'type')}>뒤로</Button>
-          <Button variant="default" disabled={!isValid} onclick={handleAdd}>추가</Button>
+          <Button variant="outline" onclick={() => (step = 'type')}>Back</Button>
+          <Button variant="default" disabled={!isValid} onclick={handleAdd}>Add</Button>
         </Dialog.Footer>
       </div>
     {/if}

--- a/saegim-frontend/src/lib/components/settings/EngineCard.svelte
+++ b/saegim-frontend/src/lib/components/settings/EngineCard.svelte
@@ -37,7 +37,7 @@
   const ENGINE_LABELS: Record<RegisterableEngineType, string> = {
     commercial_api: 'Gemini API',
     vllm: 'vLLM',
-    split_pipeline: '레이아웃 + OCR',
+    split_pipeline: 'Layout + OCR',
   }
 
   function initEdit() {
@@ -86,7 +86,7 @@
         {isDefault
         ? 'text-amber-500'
         : 'text-muted-foreground/30 hover:text-amber-400'}"
-      title={isDefault ? '기본 엔진' : '기본 엔진으로 설정'}
+      title={isDefault ? 'Default Engine' : 'Set as Default Engine'}
       onclick={() => !isDefault && onsetdefault?.()}
     >
       <svg class="h-5 w-5" fill={isDefault ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -109,7 +109,7 @@
           </svg>
         </div>
       {:else if connectionStatus?.success === true}
-        <div class="text-emerald-500" title="연결됨">
+        <div class="text-emerald-500" title="Connected">
           <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
             <circle cx="10" cy="10" r="5" />
           </svg>
@@ -121,7 +121,7 @@
           </svg>
         </div>
       {:else}
-        <div class="text-muted-foreground/40" title="미테스트">
+        <div class="text-muted-foreground/40" title="Untested">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
@@ -133,7 +133,7 @@
     <button
       type="button"
       class="text-muted-foreground hover:text-destructive shrink-0 transition-colors"
-      title="삭제"
+      title="Delete"
       onclick={() => ondelete?.()}
     >
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -146,7 +146,7 @@
   {#if isExpanded}
     <div class="border-border space-y-3 border-t p-4">
       <div>
-        <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-name-{engineId}">이름</label>
+        <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-name-{engineId}">Name</label>
         <input
           id="edit-name-{engineId}"
           type="text"
@@ -167,7 +167,7 @@
           />
         </div>
         <div>
-          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-model-{engineId}">모델</label>
+          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-model-{engineId}">Model</label>
           <select
             id="edit-model-{engineId}"
             class="border-input bg-background text-foreground focus:border-ring focus:ring-ring block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
@@ -179,12 +179,12 @@
           </select>
         </div>
         <div>
-          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-prompt-{engineId}">OCR 프롬프트 (선택)</label>
+          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-prompt-{engineId}">OCR Prompt (Optional)</label>
           <textarea
             id="edit-prompt-{engineId}"
             class="border-input bg-background text-foreground focus:border-ring focus:ring-ring block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
             rows="4"
-            placeholder="비워두면 기본 레이아웃 분석 프롬프트를 사용합니다."
+            placeholder="Leave empty to use the default layout analysis prompt."
             value={String(editConfig.prompt ?? '')}
             oninput={(e) => (editConfig = { ...editConfig, prompt: (e.target as HTMLTextAreaElement).value })}
           ></textarea>
@@ -194,7 +194,7 @@
       {#if engine.engine_type === 'vllm'}
         <div class="grid grid-cols-3 gap-3">
           <div class="col-span-2">
-            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-host-{engineId}">호스트</label>
+            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-host-{engineId}">Host</label>
             <input
               id="edit-host-{engineId}"
               type="text"
@@ -204,7 +204,7 @@
             />
           </div>
           <div>
-            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-port-{engineId}">포트</label>
+            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-port-{engineId}">Port</label>
             <input
               id="edit-port-{engineId}"
               type="number"
@@ -215,7 +215,7 @@
           </div>
         </div>
         <div>
-          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-vllm-model-{engineId}">모델</label>
+          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-vllm-model-{engineId}">Model</label>
           <input
             id="edit-vllm-model-{engineId}"
             type="text"
@@ -228,7 +228,7 @@
 
       {#if engine.engine_type === 'split_pipeline'}
         <div>
-          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-layout-provider-{engineId}">레이아웃 감지기</label>
+          <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-layout-provider-{engineId}">Layout Detector</label>
           <select
             id="edit-layout-provider-{engineId}"
             class="border-input bg-background text-foreground focus:border-ring focus:ring-ring block w-full rounded-md border px-3 py-2 text-sm focus:ring-1"
@@ -241,7 +241,7 @@
         </div>
         {#if String(editConfig.layout_provider ?? 'docling') === 'docling'}
           <div>
-            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-docling-{engineId}">Docling 모델</label>
+            <label class="text-muted-foreground mb-1 block text-xs font-medium" for="edit-docling-{engineId}">Docling Model</label>
             <input
               id="edit-docling-{engineId}"
               type="text"
@@ -279,9 +279,9 @@
 
       <div class="flex items-center justify-end gap-2 pt-1">
         <Button variant="outline" size="sm" disabled={isTesting} onclick={() => ontest?.()}>
-          {isTesting ? '테스트 중...' : '연결 테스트'}
+          {isTesting ? 'Testing...' : 'Connection Test'}
         </Button>
-        <Button variant="default" size="sm" onclick={handleSave}>저장</Button>
+        <Button variant="default" size="sm" onclick={handleSave}>Save</Button>
       </div>
     </div>
   {/if}

--- a/saegim-frontend/src/lib/components/settings/OcrSettingsPanel.svelte
+++ b/saegim-frontend/src/lib/components/settings/OcrSettingsPanel.svelte
@@ -40,16 +40,16 @@
   <!-- Header -->
   <div class="flex items-center justify-between">
     <div>
-      <h3 class="text-foreground text-sm font-semibold">OCR 엔진 관리</h3>
+      <h3 class="text-foreground text-sm font-semibold">OCR Engine Management</h3>
       <p class="text-muted-foreground text-xs">
-        엔진 인스턴스를 등록하고 관리하세요. ★ 표시된 엔진이 전체 페이지 OCR에 사용됩니다.
+        Register and manage engine instances. The starred engine is used for full-page OCR.
       </p>
     </div>
     <Button variant="outline" size="sm" onclick={() => (showAddDialog = true)}>
       <svg class="mr-1 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
       </svg>
-      엔진 추가
+      Add Engine
     </Button>
   </div>
 
@@ -72,9 +72,9 @@
     </div>
   {:else}
     <div class="border-border rounded-lg border border-dashed p-8 text-center">
-      <p class="text-muted-foreground text-sm">등록된 엔진이 없습니다.</p>
+      <p class="text-muted-foreground text-sm">No engines registered.</p>
       <p class="text-muted-foreground mt-1 text-xs">
-        "엔진 추가" 버튼을 눌러 OCR 엔진을 등록하세요.
+        Use the "Add Engine" button to register an OCR engine.
       </p>
     </div>
   {/if}
@@ -88,7 +88,7 @@
       <div>
         <span class="text-foreground text-xs font-medium">pdfminer</span>
         <span class="text-muted-foreground text-xs">
-          — 항상 사용 가능한 기본 폴백 엔진입니다. 기본 엔진이 설정되지 않으면 pdfminer가 사용됩니다.
+          - always available fallback engine. pdfminer is used when no default engine is configured.
         </span>
       </div>
     </div>

--- a/saegim-frontend/src/lib/components/settings/ProjectMembersPanel.svelte
+++ b/saegim-frontend/src/lib/components/settings/ProjectMembersPanel.svelte
@@ -61,9 +61,9 @@
   <!-- Header -->
   <div class="flex items-center justify-between">
     <div>
-      <h3 class="text-foreground text-sm font-semibold">멤버 관리</h3>
+      <h3 class="text-foreground text-sm font-semibold">Member Management</h3>
       <p class="text-muted-foreground text-xs">
-        프로젝트 멤버를 추가하고 역할을 관리하세요.
+        Add project members and manage roles.
       </p>
     </div>
     {#if isOwnerOrAdmin}
@@ -77,7 +77,7 @@
         >
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
         </svg>
-        멤버 추가
+        Add Member
       </Button>
     {/if}
   </div>
@@ -88,11 +88,11 @@
       <table class="w-full text-sm">
         <thead>
           <tr class="bg-muted/50 border-border border-b">
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">이름</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">이메일</th>
-            <th class="text-muted-foreground px-4 py-2 text-left font-medium">역할</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Name</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Email</th>
+            <th class="text-muted-foreground px-4 py-2 text-left font-medium">Role</th>
             {#if isOwnerOrAdmin}
-              <th class="text-muted-foreground px-4 py-2 text-right font-medium">액션</th>
+              <th class="text-muted-foreground px-4 py-2 text-right font-medium">Action</th>
             {/if}
           </tr>
         </thead>
@@ -102,7 +102,7 @@
               <td class="text-foreground px-4 py-3 font-medium">
                 {member.user_name}
                 {#if member.user_id === currentUserId}
-                  <span class="text-muted-foreground text-xs">(나)</span>
+                  <span class="text-muted-foreground text-xs">(You)</span>
                 {/if}
               </td>
               <td class="text-muted-foreground px-4 py-3">{member.user_email}</td>
@@ -133,7 +133,7 @@
                       class="text-destructive hover:text-destructive h-7 px-2 text-xs"
                       onclick={() => (confirmRemoveUserId = member.user_id)}
                     >
-                      제거
+                      Remove
                     </Button>
                   {/if}
                 </td>
@@ -145,10 +145,10 @@
     </div>
   {:else}
     <div class="border-border rounded-lg border border-dashed p-8 text-center">
-      <p class="text-muted-foreground text-sm">멤버가 없습니다.</p>
+      <p class="text-muted-foreground text-sm">No members.</p>
       {#if isOwnerOrAdmin}
         <p class="text-muted-foreground mt-1 text-xs">
-          "멤버 추가" 버튼을 눌러 프로젝트 멤버를 등록하세요.
+          Use the "Add Member" button to add project members.
         </p>
       {/if}
     </div>
@@ -162,19 +162,19 @@
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     role="dialog"
     aria-modal="true"
-    aria-label="멤버 제거 확인"
+    aria-label="Confirm member removal"
   >
     <div class="bg-background mx-4 w-full max-w-sm rounded-lg p-6 shadow-lg">
-      <h3 class="text-foreground mb-2 text-lg font-semibold">멤버 제거</h3>
+      <h3 class="text-foreground mb-2 text-lg font-semibold">Remove Member</h3>
       <p class="text-muted-foreground mb-4 text-sm">
-        {memberToRemove?.user_name ?? '이 멤버'}을(를) 프로젝트에서 제거하시겠습니까?
+        Remove {memberToRemove?.user_name ?? 'this member'} from the project?
       </p>
       <div class="flex justify-end gap-2">
         <Button variant="outline" size="sm" onclick={() => (confirmRemoveUserId = null)}>
-          취소
+          Cancel
         </Button>
         <Button variant="destructive" size="sm" onclick={handleRemoveConfirm}>
-          제거
+          Remove
         </Button>
       </div>
     </div>

--- a/saegim-frontend/src/lib/stores/pdf.svelte.ts
+++ b/saegim-frontend/src/lib/stores/pdf.svelte.ts
@@ -49,7 +49,7 @@ class PdfStore {
       this.currentPageNo = 1
       this.currentUrl = url
     } catch (e) {
-      const msg = e instanceof Error ? e.message : 'PDF 문서를 불러올 수 없습니다.'
+      const msg = e instanceof Error ? e.message : 'Unable to load PDF document.'
       console.warn('[saegim] PDF store loadDocument failed:', msg, 'url:', url)
       this.error = msg
       this.pdfDoc = null

--- a/saegim-frontend/src/lib/types/categories.ts
+++ b/saegim-frontend/src/lib/types/categories.ts
@@ -1,5 +1,5 @@
 /**
- * Category types, attribute enums, and Korean labels for the labeling UI.
+ * Category types, attribute enums, and display labels for the labeling UI.
  */
 
 // --- Block-level categories (18 types) ---
@@ -118,19 +118,19 @@ export const CATEGORY_ATTRIBUTES: Partial<Record<BlockCategoryType, readonly Att
     text_block: [
       {
         key: 'text_language',
-        label: '텍스트 언어',
+        label: 'Text Language',
         type: 'select',
         options: TEXT_LANGUAGES,
       },
       {
         key: 'text_background',
-        label: '배경',
+        label: 'Background',
         type: 'select',
         options: TEXT_BACKGROUNDS,
       },
       {
         key: 'text_rotate',
-        label: '회전',
+        label: 'Rotation',
         type: 'select',
         options: TEXT_ROTATIONS,
       },
@@ -138,19 +138,19 @@ export const CATEGORY_ATTRIBUTES: Partial<Record<BlockCategoryType, readonly Att
     title: [
       {
         key: 'text_language',
-        label: '텍스트 언어',
+        label: 'Text Language',
         type: 'select',
         options: TEXT_LANGUAGES,
       },
       {
         key: 'text_background',
-        label: '배경',
+        label: 'Background',
         type: 'select',
         options: TEXT_BACKGROUNDS,
       },
       {
         key: 'text_rotate',
-        label: '회전',
+        label: 'Rotation',
         type: 'select',
         options: TEXT_ROTATIONS,
       },
@@ -158,94 +158,94 @@ export const CATEGORY_ATTRIBUTES: Partial<Record<BlockCategoryType, readonly Att
     table: [
       {
         key: 'table_layout',
-        label: '테이블 방향',
+        label: 'Table Orientation',
         type: 'select',
         options: TABLE_LAYOUTS,
       },
-      { key: 'with_span', label: '병합 셀', type: 'toggle' },
-      { key: 'line', label: '선 스타일', type: 'select', options: TABLE_LINES },
+      { key: 'with_span', label: 'Merged Cells', type: 'toggle' },
+      { key: 'line', label: 'Line Style', type: 'select', options: TABLE_LINES },
       {
         key: 'language',
-        label: '테이블 언어',
+        label: 'Table Language',
         type: 'select',
         options: TABLE_LANGUAGES,
       },
-      { key: 'include_equation', label: '수식 포함', type: 'toggle' },
-      { key: 'include_background', label: '배경 포함', type: 'toggle' },
-      { key: 'table_vertical', label: '세로 회전', type: 'toggle' },
+      { key: 'include_equation', label: 'Contains Formula', type: 'toggle' },
+      { key: 'include_background', label: 'Contains Background', type: 'toggle' },
+      { key: 'table_vertical', label: 'Vertical Rotation', type: 'toggle' },
     ],
     equation_isolated: [
       {
         key: 'formula_type',
-        label: '수식 유형',
+        label: 'Formula Type',
         type: 'select',
         options: FORMULA_TYPES,
       },
       {
         key: 'equation_language',
-        label: '수식 언어',
+        label: 'Formula Language',
         type: 'select',
         options: EQUATION_LANGUAGES,
       },
     ],
   }
 
-// --- Korean labels for UI display ---
+// --- Labels for UI display ---
 
 export const CATEGORY_LABELS: Record<BlockCategoryType, string> = {
-  title: '제목',
-  text_block: '본문 텍스트',
-  figure: '그림',
-  figure_caption: '그림 설명',
-  figure_footnote: '그림 주석',
-  table: '테이블',
-  table_caption: '테이블 설명',
-  table_footnote: '테이블 주석',
-  equation_isolated: '별행 수식',
-  equation_caption: '수식 번호',
-  header: '머리글',
-  footer: '바닥글',
-  page_number: '페이지 번호',
-  page_footnote: '페이지 각주',
-  abandon: '무시 대상',
-  code_txt: '코드 블록',
-  code_txt_caption: '코드 설명',
-  reference: '참고문헌',
+  title: 'Title',
+  text_block: 'Body Text',
+  figure: 'Figure',
+  figure_caption: 'Figure Caption',
+  figure_footnote: 'Figure Footnote',
+  table: 'Table',
+  table_caption: 'Table Caption',
+  table_footnote: 'Table Footnote',
+  equation_isolated: 'Isolated Equation',
+  equation_caption: 'Equation Number',
+  header: 'Header',
+  footer: 'Footer',
+  page_number: 'Page Number',
+  page_footnote: 'Page Footnote',
+  abandon: 'Ignored Content',
+  code_txt: 'Code Block',
+  code_txt_caption: 'Code Caption',
+  reference: 'Reference',
 }
 
 export const SPAN_LABELS: Record<SpanCategoryType, string> = {
-  text_span: '텍스트 라인',
-  equation_ignore: '무시할 수식',
-  equation_inline: '인라인 수식',
-  footnote_mark: '각주 마크',
+  text_span: 'Text Line',
+  equation_ignore: 'Ignored Equation',
+  equation_inline: 'Inline Equation',
+  footnote_mark: 'Footnote Mark',
 }
 
-/** Korean labels for page-level attribute values */
+/** Labels for page-level attribute values */
 export const DATA_SOURCE_LABELS: Record<DataSource, string> = {
-  academic_literature: '학술 논문',
+  academic_literature: 'Academic Literature',
   PPT2PDF: 'PPT → PDF',
-  book: '도서',
-  colorful_textbook: '컬러 교과서',
-  exam_paper: '시험지',
-  note: '노트',
-  magazine: '잡지',
-  research_report: '연구 보고서',
-  newspaper: '신문',
-  government_doc: '공문서',
-  financial_report_kr: '재무보고서',
+  book: 'Book',
+  colorful_textbook: 'Colorful Textbook',
+  exam_paper: 'Exam Paper',
+  note: 'Note',
+  magazine: 'Magazine',
+  research_report: 'Research Report',
+  newspaper: 'Newspaper',
+  government_doc: 'Government Document',
+  financial_report_kr: 'Financial Report',
 }
 
 export const PAGE_LANGUAGE_LABELS: Record<PageLanguage, string> = {
-  ko: '한국어',
-  en: '영어',
-  ko_en_mixed: '한영 혼합',
-  ko_ch_mixed: '한중 혼합',
+  ko: 'Korean',
+  en: 'English',
+  ko_en_mixed: 'Korean-English Mixed',
+  ko_ch_mixed: 'Korean-Chinese Mixed',
 }
 
 export const PAGE_LAYOUT_LABELS: Record<PageLayout, string> = {
-  single_column: '단일 열',
-  double_column: '이중 열',
-  three_column: '삼중 열',
-  '1andmore_column': '복합 열',
-  other_layout: '기타',
+  single_column: 'Single Column',
+  double_column: 'Double Column',
+  three_column: 'Three Columns',
+  '1andmore_column': 'Mixed Columns',
+  other_layout: 'Other',
 }

--- a/saegim-frontend/src/routes/+page.svelte
+++ b/saegim-frontend/src/routes/+page.svelte
@@ -22,9 +22,9 @@
       projects = await listProjects()
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인하세요.'
+        error = 'Cannot connect to the backend server. Make sure it is running.'
       } else {
-        error = '프로젝트 목록을 불러오는 데 실패했습니다.'
+        error = 'Failed to load projects.'
       }
     } finally {
       isLoading = false
@@ -44,7 +44,7 @@
       newProjectName = ''
       newProjectDescription = ''
     } catch {
-      error = '프로젝트 생성에 실패했습니다.'
+      error = 'Failed to create project.'
     } finally {
       isCreating = false
     }
@@ -53,12 +53,12 @@
   async function handleDeleteProject(e: Event, projectId: string) {
     e.preventDefault()
     e.stopPropagation()
-    if (!confirm('이 프로젝트와 모든 문서를 삭제하시겠습니까?')) return
+    if (!confirm('Delete this project and all documents?')) return
     try {
       await deleteProject(projectId)
       projects = projects.filter((p) => p.id !== projectId)
     } catch {
-      error = '프로젝트 삭제에 실패했습니다.'
+      error = 'Failed to delete project.'
     }
   }
 
@@ -74,15 +74,15 @@
     <div class="mx-auto max-w-4xl">
       <div class="mb-8 flex items-center justify-between">
         <div>
-          <h1 class="text-foreground text-2xl font-bold">프로젝트</h1>
-          <p class="text-muted-foreground mt-1 text-sm">문서 레이블링 프로젝트를 관리합니다</p>
+          <h1 class="text-foreground text-2xl font-bold">Project</h1>
+          <p class="text-muted-foreground mt-1 text-sm">Manage document labeling projects</p>
         </div>
-        <Button variant="default" onclick={() => (showCreateDialog = true)}>새 프로젝트</Button>
+        <Button variant="default" onclick={() => (showCreateDialog = true)}>New Project</Button>
       </div>
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="프로젝트 불러오는 중..." />
+          <LoadingSpinner message="Loading projects..." />
         </div>
       {:else if error}
         <div
@@ -106,7 +106,7 @@
             </svg>
           </div>
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadProjects}>다시 시도</Button>
+          <Button variant="outline" onclick={loadProjects}>Retry</Button>
         </div>
       {:else if projects.length === 0}
         <div class="bg-muted border-border rounded-2xl border p-16 text-center">
@@ -127,12 +127,12 @@
               />
             </svg>
           </div>
-          <p class="text-muted-foreground mb-2 text-lg font-medium">아직 프로젝트가 없습니다</p>
+          <p class="text-muted-foreground mb-2 text-lg font-medium">No projects yet</p>
           <p class="text-muted-foreground mb-6 text-sm">
-            첫 프로젝트를 만들어 문서 레이블링을 시작하세요.
+            Create your first project to start labeling documents.
           </p>
           <Button variant="default" onclick={() => (showCreateDialog = true)}>
-            첫 프로젝트 만들기
+            Create First Project
           </Button>
         </div>
       {:else}
@@ -159,7 +159,7 @@
                   class="text-muted-foreground hover:text-destructive text-xs transition-colors"
                   onclick={(e) => handleDeleteProject(e, project.id)}
                 >
-                  삭제
+                  Delete
                 </button>
               </div>
             </div>
@@ -172,43 +172,43 @@
   {#if showCreateDialog}
     <div class="modal-backdrop fixed inset-0 z-50 flex items-center justify-center">
       <div class="bg-card border-border mx-4 w-full max-w-md rounded-2xl border p-6 shadow-2xl">
-        <h2 class="text-foreground mb-1 text-lg font-semibold">새 프로젝트 만들기</h2>
-        <p class="text-muted-foreground mb-5 text-sm">프로젝트 정보를 입력하세요.</p>
+        <h2 class="text-foreground mb-1 text-lg font-semibold">Create New Project</h2>
+        <p class="text-muted-foreground mb-5 text-sm">Enter project details.</p>
         <div class="space-y-4">
           <div>
             <label class="text-foreground mb-1.5 block text-sm font-medium" for="project-name"
-              >프로젝트 이름</label
+              >Project Name</label
             >
             <input
               id="project-name"
               type="text"
               class="border-border focus:border-ring focus:ring-ring/20 bg-background text-foreground block w-full rounded-lg border px-3 py-2.5 text-sm transition-all outline-none focus:ring-2"
               bind:value={newProjectName}
-              placeholder="프로젝트 이름을 입력하세요"
+              placeholder="Enter a project name"
             />
           </div>
           <div>
             <label
               class="text-foreground mb-1.5 block text-sm font-medium"
-              for="project-description">설명 (선택)</label
+              for="project-description">Description (Optional)</label
             >
             <textarea
               id="project-description"
               class="border-border focus:border-ring focus:ring-ring/20 bg-background text-foreground block w-full resize-none rounded-lg border px-3 py-2.5 text-sm transition-all outline-none focus:ring-2"
               bind:value={newProjectDescription}
-              placeholder="프로젝트에 대한 설명을 입력하세요"
+              placeholder="Enter a project description"
               rows="3"
             ></textarea>
           </div>
         </div>
         <div class="mt-6 flex justify-end gap-2">
-          <Button variant="outline" onclick={() => (showCreateDialog = false)}>취소</Button>
+          <Button variant="outline" onclick={() => (showCreateDialog = false)}>Cancel</Button>
           <Button
             variant="default"
             disabled={!newProjectName.trim() || isCreating}
             onclick={handleCreateProject}
           >
-            {isCreating ? '생성 중...' : '생성'}
+            {isCreating ? 'Creating...' : 'Create'}
           </Button>
         </div>
       </div>

--- a/saegim-frontend/src/routes/account/security/+page.svelte
+++ b/saegim-frontend/src/routes/account/security/+page.svelte
@@ -19,10 +19,10 @@
 
   let loginIdStatus = $state<'idle' | 'invalid' | 'checking' | 'available' | 'taken'>('idle')
   let loginIdHint = $derived.by(() => {
-    if (loginIdStatus === 'invalid') return 'ID는 3자 이상이어야 합니다.'
-    if (loginIdStatus === 'checking') return 'ID 중복 확인 중입니다...'
-    if (loginIdStatus === 'available') return '사용 가능한 ID입니다.'
-    if (loginIdStatus === 'taken') return '이미 사용 중인 ID입니다.'
+    if (loginIdStatus === 'invalid') return 'ID must be at least 3 characters.'
+    if (loginIdStatus === 'checking') return 'Checking ID availability...'
+    if (loginIdStatus === 'available') return 'ID is available.'
+    if (loginIdStatus === 'taken') return 'ID is already in use.'
     return null
   })
 
@@ -56,12 +56,12 @@
     if (err instanceof ApiError && err.body && typeof err.body === 'object' && 'detail' in err.body) {
       const detail = (err.body as { detail: unknown }).detail
       if (typeof detail === 'string') {
-        if (detail.includes('login ID')) return '이미 사용 중인 ID입니다.'
-        if (detail.includes('email')) return '이미 사용 중인 이메일입니다.'
+        if (detail.includes('login ID')) return 'ID is already in use.'
+        if (detail.includes('email')) return 'Email is already in use.'
         return detail
       }
     }
-    return '계정 정보 변경 중 오류가 발생했습니다. 다시 시도해 주세요.'
+    return 'An error occurred while updating account information. Please try again.'
   }
 
   async function handleSubmit(e: SubmitEvent) {
@@ -75,21 +75,21 @@
 
     if (!currentPassword) return
     if (!hasLoginId && !hasEmail && !hasPassword) {
-      error = '변경할 항목(ID, 이메일, 비밀번호) 중 하나 이상을 입력해 주세요.'
+      error = 'Enter at least one field to update: ID, email, or password.'
       return
     }
 
     if (authStore.mustChangePassword && !hasPassword) {
-      error = '초기 계정은 비밀번호를 반드시 변경해야 합니다.'
+      error = 'The initial account must change its password.'
       return
     }
 
     if (hasPassword && newPassword !== newPasswordConfirm) {
-      error = '새 비밀번호와 비밀번호 확인이 일치하지 않습니다.'
+      error = 'New password and confirmation do not match.'
       return
     }
     if (hasPassword && newPassword.length < 8) {
-      error = '새 비밀번호는 최소 8자 이상이어야 합니다.'
+      error = 'New password must be at least 8 characters.'
       return
     }
 
@@ -101,7 +101,7 @@
         loginIdStatus = available ? 'available' : 'taken'
       }
       if (!available) {
-        error = '이미 사용 중인 ID입니다.'
+        error = 'ID is already in use.'
         return
       }
     }
@@ -118,11 +118,11 @@
       })
 
       authStore.setToken(response.access_token)
-      success = '계정 정보가 변경되었습니다.'
+      success = 'Account information updated.'
       await goto('/')
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
-        error = '현재 비밀번호가 올바르지 않습니다.'
+        error = 'Current password is incorrect.'
       } else {
         error = parseErrorMessage(err)
       }
@@ -135,8 +135,8 @@
 <div class="flex min-h-screen items-center justify-center px-4">
   <Card.Root class="w-full max-w-md">
     <Card.Header class="text-center">
-      <Card.Title class="text-2xl font-bold">계정 보안 설정</Card.Title>
-      <Card.Description>ID / 이메일 / 비밀번호를 변경할 수 있습니다.</Card.Description>
+      <Card.Title class="text-2xl font-bold">Account Security Settings</Card.Title>
+      <Card.Description>Update your ID, email, or password.</Card.Description>
     </Card.Header>
     <Card.Content>
       <form onsubmit={handleSubmit} class="space-y-4">
@@ -157,7 +157,7 @@
         {/if}
 
         <div class="space-y-2">
-          <Label for="current-password">현재 비밀번호</Label>
+          <Label for="current-password">Current Password</Label>
           <Input
             id="current-password"
             type="password"
@@ -168,12 +168,12 @@
         </div>
 
         <div class="space-y-2">
-          <Label for="new-login-id">새 ID (선택)</Label>
+          <Label for="new-login-id">New ID (Optional)</Label>
           <Input
             id="new-login-id"
             type="text"
             bind:value={newLoginId}
-            placeholder="변경할 ID"
+            placeholder="New ID"
             autocomplete="username"
           />
           {#if loginIdHint}
@@ -190,17 +190,17 @@
         </div>
 
         <div class="space-y-2">
-          <Label for="new-email">새 이메일 (선택)</Label>
+          <Label for="new-email">New Email (Optional)</Label>
           <Input id="new-email" type="email" bind:value={newEmail} placeholder="new@example.com" />
         </div>
 
         <div class="space-y-2">
-          <Label for="new-password">새 비밀번호 (선택)</Label>
+          <Label for="new-password">New Password (Optional)</Label>
           <Input id="new-password" type="password" bind:value={newPassword} minlength={8} />
         </div>
 
         <div class="space-y-2">
-          <Label for="new-password-confirm">새 비밀번호 확인</Label>
+          <Label for="new-password-confirm">Confirm New Password</Label>
           <Input
             id="new-password-confirm"
             type="password"
@@ -210,7 +210,7 @@
         </div>
 
         <Button type="submit" class="w-full" disabled={isSubmitting}>
-          {isSubmitting ? '변경 중...' : '계정 정보 변경'}
+          {isSubmitting ? 'Updating...' : 'Update Account'}
         </Button>
       </form>
     </Card.Content>

--- a/saegim-frontend/src/routes/admin/+page.svelte
+++ b/saegim-frontend/src/routes/admin/+page.svelte
@@ -55,9 +55,9 @@
       stats = statsData
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '관리자 데이터를 불러오는 데 실패했습니다.'
+        error = 'Admin Failed to load data.'
       }
     } finally {
       isLoading = false
@@ -69,9 +69,9 @@
     try {
       const updated = await updateAdminUser(userId, { role })
       users = users.map((u) => (u.id === userId ? updated : u))
-      showSuccess('역할이 변경되었습니다.')
+      showSuccess('Role updated.')
     } catch {
-      error = '역할 변경에 실패했습니다.'
+      error = 'Failed to update role.'
     }
   }
 
@@ -80,9 +80,9 @@
     try {
       const updated = await updateAdminUser(userId, { is_active: isActive })
       users = users.map((u) => (u.id === userId ? updated : u))
-      showSuccess(isActive ? '사용자가 활성화되었습니다.' : '사용자가 비활성화되었습니다.')
+      showSuccess(isActive ? 'User activated.' : 'User deactivated.')
     } catch {
-      error = '사용자 상태 변경에 실패했습니다.'
+      error = 'Failed to update user status.'
     }
   }
 
@@ -94,18 +94,18 @@
 </script>
 
 <div class="flex h-full flex-col">
-  <Header title="관리자 대시보드" />
+  <Header title="Admin Dashboard" />
 
   <div class="bg-background flex-1 overflow-y-auto p-8">
     <div class="mx-auto max-w-5xl">
       <div class="mb-6">
-        <h1 class="text-foreground text-2xl font-bold">관리자 대시보드</h1>
-        <p class="text-muted-foreground mt-1 text-sm">시스템 전체를 관리하세요.</p>
+        <h1 class="text-foreground text-2xl font-bold">Admin Dashboard</h1>
+        <p class="text-muted-foreground mt-1 text-sm">Manage the whole system.</p>
       </div>
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="데이터 불러오는 중..." />
+          <LoadingSpinner message="Loading data..." />
         </div>
       {:else if error}
         <div
@@ -113,7 +113,7 @@
             rounded-xl border p-6 text-center"
         >
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadData}>다시 시도</Button>
+          <Button variant="outline" onclick={loadData}>Retry</Button>
         </div>
       {:else}
         {#if successMessage}
@@ -128,9 +128,9 @@
 
         <Tabs.Root value="users" class="w-full">
           <Tabs.List class="mb-4">
-            <Tabs.Trigger value="users">사용자 관리</Tabs.Trigger>
-            <Tabs.Trigger value="projects">프로젝트 관리</Tabs.Trigger>
-            <Tabs.Trigger value="stats">시스템 현황</Tabs.Trigger>
+            <Tabs.Trigger value="users">User Admin</Tabs.Trigger>
+            <Tabs.Trigger value="projects">Project Admin</Tabs.Trigger>
+            <Tabs.Trigger value="stats">System Status</Tabs.Trigger>
           </Tabs.List>
 
           <Tabs.Content value="users">

--- a/saegim-frontend/src/routes/label/[pageId]/+page.svelte
+++ b/saegim-frontend/src/routes/label/[pageId]/+page.svelte
@@ -65,10 +65,10 @@
   }
 
   const statusLabels: Record<PageStatus, string> = {
-    pending: '대기',
-    in_progress: '진행중',
-    submitted: '제출됨',
-    reviewed: '검토완료',
+    pending: 'Pending',
+    in_progress: 'In Progress',
+    submitted: 'Submitted',
+    reviewed: 'Reviewed',
   }
 
   let isLockedByOther = $derived(
@@ -156,9 +156,9 @@
       }
     } catch (e) {
       if (e instanceof NetworkError) {
-        annotationStore.setError('백엔드 서버에 연결할 수 없습니다.')
+        annotationStore.setError('Cannot connect to the backend server.')
       } else {
-        annotationStore.setError('페이지를 불러오는 데 실패했습니다.')
+        annotationStore.setError('Failed to load page.')
       }
     } finally {
       annotationStore.setLoading(false)
@@ -175,9 +175,9 @@
         annotation_data: annotationStore.annotationData,
       })
       annotationStore.markSaved()
-      uiStore.showNotification('저장 완료', 'success')
+      uiStore.showNotification('Save Complete', 'success')
     } catch {
-      uiStore.showNotification('저장 실패', 'error')
+      uiStore.showNotification('Failed to save', 'error')
     } finally {
       saving = false
     }
@@ -205,10 +205,10 @@
       autoSaveFailCount++
       if (autoSaveFailCount >= MAX_AUTO_SAVE_FAILURES) {
         autosaveStore.setEnabled(false)
-        uiStore.showNotification('자동 저장 반복 실패로 비활성화됨', 'error')
+        uiStore.showNotification('Auto-save disabled after repeated failures', 'error')
         autoSaveFailCount = 0
       } else {
-        uiStore.showNotification('자동 저장 실패', 'error')
+        uiStore.showNotification('Auto-save failed', 'error')
       }
     }
   }
@@ -216,17 +216,17 @@
   async function handleSubmit() {
     const pageId = page.params.pageId
     if (!pageId) return
-    if (!confirm('이 페이지를 검수 제출하시겠습니까?')) return
+    if (!confirm('Submit this page for review?')) return
     submitting = true
     try {
       const updated = await submitPage(pageId)
       pageData = updated
-      uiStore.showNotification('검수 제출 완료', 'success')
+      uiStore.showNotification('Submit for Review Complete', 'success')
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
-        uiStore.showNotification('제출할 수 없는 상태입니다', 'error')
+        uiStore.showNotification('Cannot submit in the current state', 'error')
       } else {
-        uiStore.showNotification('제출에 실패했습니다', 'error')
+        uiStore.showNotification('Failed to submit', 'error')
       }
     } finally {
       submitting = false
@@ -235,11 +235,11 @@
 
   function handleRevertToLastSaved(): void {
     if (!annotationStore.isDirty) return
-    if (!confirm('저장되지 않은 변경사항을 버리고 마지막 저장 상태로 되돌리시겠습니까?')) return
+    if (!confirm('Discard unsaved changes and revert to the last saved state?')) return
     reverting = true
     try {
       annotationStore.revertToLastSaved()
-      uiStore.showNotification('마지막 저장 상태로 되돌렸습니다', 'success')
+      uiStore.showNotification('Reverted to the last saved state', 'success')
     } finally {
       reverting = false
     }
@@ -314,20 +314,20 @@
           text: result.text,
           ...(engineId ? { ocr_engine: engineId } : {}),
         })
-        uiStore.showNotification('텍스트가 추출되었습니다', 'success')
+        uiStore.showNotification('Text extracted', 'success')
       } else {
-        uiStore.showNotification('텍스트를 찾지 못했습니다', 'info')
+        uiStore.showNotification('No text found', 'info')
       }
     } catch (e) {
       if (e instanceof ApiError && e.status === 404) {
-        uiStore.showNotification('OCR 엔드포인트가 아직 준비되지 않았습니다', 'info')
+        uiStore.showNotification('OCR endpoint is not ready yet', 'info')
       } else if (e instanceof ApiError && e.status === 503) {
         uiStore.showNotification(
-          'OCR 엔진이 설정되지 않았습니다. 프로젝트 설정에서 OCR 엔진을 구성해주세요.',
+          'OCR engine is not configured. Configure an OCR engine in project settings.',
           'info',
         )
       } else {
-        uiStore.showNotification('텍스트 추출에 실패했습니다', 'error')
+        uiStore.showNotification('Failed to extract text', 'error')
       }
     }
   }
@@ -376,7 +376,7 @@
         // No OCR engine configured — show hint without error notification
         documentStatus = 'ready'
       } else {
-        uiStore.showNotification('자동 추출에 실패했습니다', 'error')
+        uiStore.showNotification('Automatic extraction failed', 'error')
       }
     } finally {
       pageExtracting = false
@@ -385,7 +385,7 @@
 
   async function handleReExtract() {
     if (!pageData?.document_id) return
-    if (!confirm('현재 OCR 엔진으로 전체 페이지를 재추출하시겠습니까?')) return
+    if (!confirm('Re-extract the full page with the current OCR engine?')) return
     try {
       const result = await reExtractDocument(pageData.document_id)
       documentStatus = result.status
@@ -400,12 +400,12 @@
         }
         reExtractVersion++
       }
-      uiStore.showNotification('재추출이 시작되었습니다', 'success')
+      uiStore.showNotification('Re-extraction started', 'success')
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
-        uiStore.showNotification('이미 추출이 진행 중입니다', 'info')
+        uiStore.showNotification('Extraction is already in progress', 'info')
       } else {
-        uiStore.showNotification('재추출 요청에 실패했습니다', 'error')
+        uiStore.showNotification('Failed to request re-extraction', 'error')
       }
     }
   }
@@ -447,7 +447,7 @@
 
 <div class="flex h-full flex-col">
   <Header
-    title={pageData?.project_name ?? '레이블링'}
+    title={pageData?.project_name ?? 'Labeling'}
     showSave
     showRevert
     showAutoSave
@@ -468,12 +468,12 @@
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
         </svg>
-        {pageData.project_name ?? '프로젝트'}
+        {pageData.project_name ?? 'Project'}
       </a>
       <span class="text-muted-foreground mx-2">/</span>
-      <span class="text-muted-foreground">{pageData.document_filename ?? '문서'}</span>
+      <span class="text-muted-foreground">{pageData.document_filename ?? 'Document'}</span>
       <span class="text-muted-foreground mx-2">/</span>
-      <span class="text-foreground font-medium">페이지 {pageData.page_no}</span>
+      <span class="text-foreground font-medium">Page {pageData.page_no}</span>
       <span class="badge ml-2 rounded-full px-2 py-0.5 text-xs font-medium {statusColors[pageData.status]}">
         {statusLabels[pageData.status]}
       </span>
@@ -482,7 +482,7 @@
           class="ml-2 inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-xs text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
         >
           <Lock class="size-3" />
-          다른 사용자 편집 중
+          Another user is editing
         </span>
       {/if}
       {#if canSubmit}
@@ -491,17 +491,17 @@
           onclick={handleSubmit}
           disabled={submitting}
         >
-          {submitting ? '제출 중...' : '검수 제출'}
+          {submitting ? 'Submitting...' : 'Submit for Review'}
         </button>
       {/if}
       {#if ocrConfig}
         <a
           href="/projects/{pageData.project_id}/settings"
           class="bg-muted text-muted-foreground border-border hover:border-primary hover:text-primary ml-auto inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors"
-          title="OCR 엔진 설정"
+          title="OCR Engine Settings"
         >
           {getDefaultEngineName(ocrConfig)}
-          <span class="text-muted-foreground/70 ml-1 text-[10px]">(기본)</span>
+          <span class="text-muted-foreground/70 ml-1 text-[10px]">(Default)</span>
         </a>
       {/if}
     </nav>
@@ -509,7 +509,7 @@
 
   {#if annotationStore.isLoading}
     <div class="flex flex-1 items-center justify-center">
-      <LoadingSpinner message="페이지 불러오는 중..." />
+      <LoadingSpinner message="Loading page..." />
     </div>
   {:else if annotationStore.error}
     <div class="flex flex-1 items-center justify-center">
@@ -534,7 +534,7 @@
           </svg>
         </div>
         <p class="text-destructive mb-4 font-medium">{annotationStore.error}</p>
-        <Button variant="outline" onclick={loadPage}>다시 시도</Button>
+        <Button variant="outline" onclick={loadPage}>Retry</Button>
       </div>
     </div>
   {:else}
@@ -574,7 +574,7 @@
                 ? 'bg-primary text-primary-foreground shadow-sm'
                 : 'text-muted-foreground hover:bg-accent'}"
               onclick={() => canvasStore.setTool('select')}
-              title="선택 (1)"
+              title="Select (1)"
             >
               <svg
                 class="h-4 w-4"
@@ -596,7 +596,7 @@
                 ? 'bg-primary text-primary-foreground shadow-sm'
                 : 'text-muted-foreground hover:bg-accent'}"
               onclick={() => canvasStore.setTool('draw')}
-              title="그리기 (2)"
+              title="Draw (2)"
             >
               <svg
                 class="h-4 w-4"
@@ -618,7 +618,7 @@
                 ? 'bg-primary text-primary-foreground shadow-sm'
                 : 'text-muted-foreground hover:bg-accent'}"
               onclick={() => canvasStore.setTool('pan')}
-              title="이동 (3)"
+              title="Pan (3)"
             >
               <svg
                 class="h-4 w-4"
@@ -642,7 +642,7 @@
             <button
               class="text-muted-foreground hover:bg-accent rounded-lg p-1.5 transition-all"
               onclick={() => canvasStore.zoomOut()}
-              title="축소"
+              title="Zoom Out"
             >
               <svg
                 class="h-4 w-4"
@@ -657,14 +657,14 @@
             <button
               class="text-muted-foreground hover:bg-accent min-w-[3rem] rounded-lg px-1.5 py-1 text-center font-mono text-[11px] font-medium transition-all"
               onclick={() => canvasStore.resetView()}
-              title="1:1 보기로 리셋"
+              title="Reset to 1:1"
             >
               {Math.round(canvasStore.scale * 100)}%
             </button>
             <button
               class="text-muted-foreground hover:bg-accent rounded-lg p-1.5 transition-all"
               onclick={() => canvasStore.zoomIn()}
-              title="확대"
+              title="Zoom In"
             >
               <svg
                 class="h-4 w-4"
@@ -690,7 +690,7 @@
           />
         {:else}
           <div class="absolute inset-0 flex items-center justify-center">
-            <p class="text-muted-foreground text-sm">이미지를 불러오는 중...</p>
+            <p class="text-muted-foreground text-sm">Loading image...</p>
           </div>
         {/if}
 

--- a/saegim-frontend/src/routes/login/+page.svelte
+++ b/saegim-frontend/src/routes/login/+page.svelte
@@ -33,9 +33,9 @@
       await goto('/')
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
-        error = 'ID 또는 비밀번호가 올바르지 않습니다.'
+        error = 'Invalid ID or password.'
       } else {
-        error = '로그인 중 오류가 발생했습니다. 다시 시도해 주세요.'
+        error = 'An error occurred while signing in. Please try again.'
       }
     } finally {
       isSubmitting = false
@@ -50,7 +50,7 @@
     <Card.Root class="w-full max-w-sm">
       <Card.Header class="text-center">
         <Card.Title class="text-2xl font-bold">saegim</Card.Title>
-        <Card.Description>계정에 로그인하세요</Card.Description>
+        <Card.Description>Sign in to your account</Card.Description>
       </Card.Header>
       <Card.Content>
         <form onsubmit={handleSubmit} class="space-y-4">
@@ -75,7 +75,7 @@
           </div>
 
           <div class="space-y-2">
-            <Label for="password">비밀번호</Label>
+            <Label for="password">Password</Label>
             <Input
               id="password"
               type="password"
@@ -86,14 +86,14 @@
           </div>
 
           <Button type="submit" class="w-full" disabled={isSubmitting}>
-            {isSubmitting ? '로그인 중...' : '로그인'}
+            {isSubmitting ? 'Signing in...' : 'Sign in'}
           </Button>
         </form>
       </Card.Content>
       <Card.Footer class="justify-center">
         <p class="text-muted-foreground text-sm">
-          계정이 없으신가요?
-          <a href="/register" class="text-primary font-medium hover:underline">회원가입</a>
+          No account yet?
+          <a href="/register" class="text-primary font-medium hover:underline">Sign up</a>
         </p>
       </Card.Footer>
     </Card.Root>

--- a/saegim-frontend/src/routes/projects/[id]/+page.svelte
+++ b/saegim-frontend/src/routes/projects/[id]/+page.svelte
@@ -95,9 +95,9 @@
       ocrConfig = config
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '데이터를 불러오는 데 실패했습니다.'
+        error = 'Failed to load data.'
       }
     } finally {
       isLoading = false
@@ -116,7 +116,7 @@
       const doc = await uploadDocument(id, file)
       documents = [...documents, doc]
     } catch {
-      error = 'PDF 업로드에 실패했습니다.'
+      error = 'Failed to upload PDF.'
     } finally {
       isUploading = false
       target.value = ''
@@ -161,7 +161,7 @@
     const file = files[0]
 
     if (file.type !== 'application/pdf' && !file.name.toLowerCase().endsWith('.pdf')) {
-      error = 'PDF 파일만 업로드할 수 있습니다.'
+      error = 'Only PDF files can be uploaded.'
       return
     }
 
@@ -171,7 +171,7 @@
       const doc = await uploadDocument(id, file)
       documents = [...documents, doc]
     } catch {
-      error = 'PDF 업로드에 실패했습니다.'
+      error = 'Failed to upload PDF.'
     } finally {
       isUploading = false
     }
@@ -195,7 +195,7 @@
 
   async function handleDeleteDoc(e: Event, docId: string) {
     e.stopPropagation()
-    if (!confirm('이 문서를 삭제하시겠습니까?')) return
+    if (!confirm('Delete this document?')) return
     try {
       await deleteDocument(docId)
       documents = documents.filter((d) => d.id !== docId)
@@ -203,7 +203,7 @@
       documentPages = rest
       if (expandedDoc === docId) expandedDoc = null
     } catch {
-      error = '문서 삭제에 실패했습니다.'
+      error = 'Failed to delete document.'
     }
   }
 
@@ -215,7 +215,7 @@
     try {
       await exportProjectZip(id)
     } catch {
-      error = '프로젝트 내보내기에 실패했습니다.'
+      error = 'Failed to export project.'
     } finally {
       isExporting = false
     }
@@ -230,7 +230,7 @@
     try {
       await exportDocumentZip(id, docId)
     } catch {
-      error = '문서 내보내기에 실패했습니다.'
+      error = 'Failed to export document.'
     } finally {
       exportingDocId = null
     }
@@ -267,7 +267,7 @@
       class="relative mx-auto max-w-4xl"
       data-dropzone
       role="region"
-      aria-label="PDF 업로드 영역"
+      aria-label="PDF upload area"
       ondragenter={handleDragEnter}
       ondragover={handleDragOver}
       ondragleave={handleDragLeave}
@@ -292,8 +292,8 @@
               />
             </svg>
           </div>
-          <p class="text-primary text-lg font-medium">PDF 파일을 여기에 놓으세요</p>
-          <p class="text-muted-foreground mt-1 text-sm">파일을 놓으면 바로 업로드됩니다</p>
+          <p class="text-primary text-lg font-medium">Drop PDF files here</p>
+          <p class="text-muted-foreground mt-1 text-sm">Drop a file to upload it immediately</p>
         </div>
       {/if}
 
@@ -311,19 +311,19 @@
           >
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
-          프로젝트 목록
+          Project List
         </a>
       </div>
 
       <div class="mb-6 flex items-center justify-between">
         <div>
           <div class="flex items-center gap-2">
-            <h1 class="text-foreground text-2xl font-bold">{project?.name ?? '문서'}</h1>
+            <h1 class="text-foreground text-2xl font-bold">{project?.name ?? 'Document'}</h1>
             {#if ocrConfig}
               <a
                 href="/projects/{page.params.id}/settings"
                 class="bg-muted text-muted-foreground border-border hover:border-primary hover:text-primary inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium transition-colors"
-                title="OCR 엔진 설정"
+                title="OCR Engine Settings"
               >
                 {getDefaultEngineName(ocrConfig)}
               </a>
@@ -337,7 +337,7 @@
           <a
             href="/projects/{page.params.id}/progress"
             class="text-muted-foreground hover:text-accent-foreground hover:bg-accent border-border inline-flex h-9 items-center gap-1 rounded-lg border px-3 text-sm transition-all"
-            title="작업 현황"
+            title="Task Progress"
           >
             <svg
               class="h-4 w-4"
@@ -352,12 +352,12 @@
                 d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
               />
             </svg>
-            작업 현황
+            Task Progress
           </a>
           <a
             href="/projects/{page.params.id}/review"
             class="text-muted-foreground hover:text-accent-foreground hover:bg-accent border-border inline-flex h-9 items-center gap-1 rounded-lg border px-3 text-sm transition-all"
-            title="검수 큐"
+            title="Review Queue"
           >
             <svg
               class="h-4 w-4"
@@ -372,14 +372,14 @@
                 d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
-            검수 큐
+            Review Queue
           </a>
           <a
             href="/projects/{page.params.id}/settings"
             class="text-muted-foreground hover:text-accent-foreground hover:bg-accent border-border inline-flex h-9
               w-9 items-center justify-center
               rounded-lg border transition-all"
-            title="프로젝트 설정"
+            title="Project Settings"
           >
             <svg
               class="h-5 w-5"
@@ -418,7 +418,7 @@
                 d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
               />
             </svg>
-            {isExporting ? '내보내는 중...' : '전체 내보내기'}
+            {isExporting ? 'Exporting...' : 'Export All'}
           </Button>
           <input
             type="file"
@@ -428,13 +428,13 @@
             onchange={handleUpload}
           />
           <Button variant="default" disabled={isUploading} onclick={() => fileInput.click()}>
-            {isUploading ? '업로드 중...' : 'PDF 업로드'}
+            {isUploading ? 'Uploading...' : 'PDF Upload'}
           </Button>
         </div>
       </div>
 
       {#if isLoading}
-        <div class="py-12"><LoadingSpinner message="문서 불러오는 중..." /></div>
+        <div class="py-12"><LoadingSpinner message="Loading documents..." /></div>
       {:else if error}
         <div
           class="bg-destructive/10 dark:bg-destructive/20 border-destructive/30 rounded-xl border p-6 text-center"
@@ -457,7 +457,7 @@
             </svg>
           </div>
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadData}>다시 시도</Button>
+          <Button variant="outline" onclick={loadData}>Retry</Button>
         </div>
       {:else if documents.length === 0}
         <div class="bg-muted border-border rounded-2xl border p-16 text-center">
@@ -478,11 +478,11 @@
               />
             </svg>
           </div>
-          <p class="text-muted-foreground mb-2 text-lg font-medium">아직 문서가 없습니다</p>
+          <p class="text-muted-foreground mb-2 text-lg font-medium">No documents yet</p>
           <p class="text-muted-foreground mb-6 text-sm">
-            PDF 파일을 업로드하여 레이블링을 시작하세요.
+            Upload a PDF to start labeling.
           </p>
-          <Button variant="default" onclick={() => fileInput.click()}>PDF 업로드</Button>
+          <Button variant="default" onclick={() => fileInput.click()}>PDF Upload</Button>
         </div>
       {:else}
         <div class="space-y-3">
@@ -498,7 +498,7 @@
                   <div>
                     <h3 class="text-foreground font-medium">{doc.filename}</h3>
                     <div class="mt-1.5 flex items-center gap-2">
-                      <span class="text-muted-foreground text-sm">{doc.total_pages}페이지</span>
+                      <span class="text-muted-foreground text-sm">{doc.total_pages}Page</span>
                       <span
                         class="badge
                         {doc.status === 'ready'
@@ -512,16 +512,16 @@
                                 : 'bg-muted text-muted-foreground border-border border'}"
                       >
                         {doc.status === 'ready'
-                          ? '준비됨'
+                          ? 'Ready'
                           : doc.status === 'processing'
-                            ? '처리 중'
+                            ? 'Processing'
                             : doc.status === 'extracting'
-                              ? '추출 중'
+                              ? 'Extracting'
                               : doc.status === 'error'
-                                ? '오류'
+                                ? 'Error'
                                 : doc.status === 'extraction_failed'
-                                  ? '추출 실패'
-                                  : '업로드 중'}
+                                  ? 'Extraction Failed'
+                                  : 'Uploading'}
                       </span>
                     </div>
                   </div>
@@ -532,14 +532,14 @@
                         disabled={exportingDocId === doc.id}
                         onclick={(e) => handleExportDoc(e, doc.id)}
                       >
-                        {exportingDocId === doc.id ? '내보내는 중...' : '내보내기'}
+                        {exportingDocId === doc.id ? 'Exporting...' : 'Export'}
                       </button>
                     {/if}
                     <button
                       class="text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg px-2 py-1 text-xs transition-all"
                       onclick={(e) => handleDeleteDoc(e, doc.id)}
                     >
-                      삭제
+                      Delete
                     </button>
                     <svg
                       class="text-muted-foreground h-4 w-4 transition-transform {expandedDoc ===
@@ -585,12 +585,12 @@
                                   : 'text-muted-foreground'}"
                           >
                             {docPage.status === 'submitted'
-                              ? '완료'
+                              ? 'Complete'
                               : docPage.status === 'in_progress'
-                                ? '진행 중'
+                                ? 'In Progress'
                                 : docPage.status === 'reviewed'
-                                  ? '검토됨'
-                                  : '대기'}
+                                  ? 'Reviewed'
+                                  : 'Pending'}
                           </span>
                         </a>
                       {/each}

--- a/saegim-frontend/src/routes/projects/[id]/progress/+page.svelte
+++ b/saegim-frontend/src/routes/projects/[id]/progress/+page.svelte
@@ -15,32 +15,32 @@
 
   function roleLabel(role: string): string {
     const labels: Record<string, string> = {
-      owner: '소유자',
-      annotator: '작업자',
-      reviewer: '검수자',
+      owner: 'Owner',
+      annotator: 'Annotator',
+      reviewer: 'Reviewer',
     }
     return labels[role] ?? role
   }
 
   const statusConfig = [
-    { key: 'pending' as const, label: '대기', color: 'text-muted-foreground', bg: 'bg-muted' },
+    { key: 'pending' as const, label: 'Pending', color: 'text-muted-foreground', bg: 'bg-muted' },
     {
       key: 'in_progress' as const,
-      label: '진행 중',
+      label: 'In Progress',
       color: 'text-blue-700 dark:text-blue-300',
       bg: 'bg-blue-50 dark:bg-blue-950/30',
       border: 'border-blue-200 dark:border-blue-800',
     },
     {
       key: 'submitted' as const,
-      label: '제출됨',
+      label: 'Submitted',
       color: 'text-amber-700 dark:text-amber-300',
       bg: 'bg-amber-50 dark:bg-amber-950/30',
       border: 'border-amber-200 dark:border-amber-800',
     },
     {
       key: 'reviewed' as const,
-      label: '검토 완료',
+      label: 'Reviewed',
       color: 'text-emerald-700 dark:text-emerald-300',
       bg: 'bg-emerald-50 dark:bg-emerald-950/30',
       border: 'border-emerald-200 dark:border-emerald-800',
@@ -61,9 +61,9 @@
       progress = prog
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '데이터를 불러오는 데 실패했습니다.'
+        error = 'Failed to load data.'
       }
     } finally {
       isLoading = false
@@ -95,18 +95,18 @@
           >
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
-          {project?.name ?? '프로젝트'}
+          {project?.name ?? 'Project'}
         </a>
       </div>
 
       <div class="mb-6">
-        <h1 class="text-foreground text-2xl font-bold">작업 현황</h1>
-        <p class="text-muted-foreground mt-1 text-sm">프로젝트 전체 진행률을 확인합니다</p>
+        <h1 class="text-foreground text-2xl font-bold">Task Progress</h1>
+        <p class="text-muted-foreground mt-1 text-sm">View overall project progress</p>
       </div>
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="진행 현황 불러오는 중..." />
+          <LoadingSpinner message="Loading progress..." />
         </div>
       {:else if error}
         <div
@@ -130,17 +130,17 @@
             </svg>
           </div>
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadData}>다시 시도</Button>
+          <Button variant="outline" onclick={loadData}>Retry</Button>
         </div>
       {:else if progress}
         <!-- Summary Cards -->
         <div class="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
           <div class="card-modern p-5">
-            <div class="text-muted-foreground mb-1 text-sm">총 페이지</div>
+            <div class="text-muted-foreground mb-1 text-sm">Total Pages</div>
             <div class="text-foreground text-2xl font-bold">{progress.total_pages}</div>
           </div>
           <div class="card-modern p-5">
-            <div class="text-muted-foreground mb-1 text-sm">완료율</div>
+            <div class="text-muted-foreground mb-1 text-sm">Completion</div>
             <div class="flex items-center gap-3">
               <div class="text-foreground text-2xl font-bold">{progress.completion_rate}%</div>
               <div class="bg-muted h-2.5 flex-1 overflow-hidden rounded-full">
@@ -152,7 +152,7 @@
             </div>
           </div>
           <div class="card-modern p-5">
-            <div class="text-muted-foreground mb-1 text-sm">검수 대기</div>
+            <div class="text-muted-foreground mb-1 text-sm">Review Pending</div>
             <div class="text-foreground text-2xl font-bold">
               {progress.status_breakdown.submitted}
             </div>
@@ -174,19 +174,19 @@
         <!-- Documents Table -->
         {#if progress.documents.length > 0}
           <div class="mb-8">
-            <h2 class="text-foreground mb-3 text-lg font-semibold">문서별 진행 현황</h2>
+            <h2 class="text-foreground mb-3 text-lg font-semibold">Progress by Document</h2>
             <div class="card-modern overflow-hidden">
               <div class="overflow-x-auto">
                 <table class="w-full text-sm">
                   <thead>
                     <tr class="border-border border-b">
-                      <th class="text-muted-foreground px-4 py-3 text-left font-medium">문서</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">페이지</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">대기</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">진행</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">제출</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">완료</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">진행률</th>
+                      <th class="text-muted-foreground px-4 py-3 text-left font-medium">Document</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Page</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Pending</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">In Progress</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Submit</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Complete</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Progress</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -225,18 +225,18 @@
         <!-- Members Table -->
         {#if progress.members.length > 0}
           <div>
-            <h2 class="text-foreground mb-3 text-lg font-semibold">멤버별 활동</h2>
+            <h2 class="text-foreground mb-3 text-lg font-semibold">Activity by Member</h2>
             <div class="card-modern overflow-hidden">
               <div class="overflow-x-auto">
                 <table class="w-full text-sm">
                   <thead>
                     <tr class="border-border border-b">
-                      <th class="text-muted-foreground px-4 py-3 text-left font-medium">이름</th>
-                      <th class="text-muted-foreground px-3 py-3 text-left font-medium">역할</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">할당</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">진행</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">제출</th>
-                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">완료</th>
+                      <th class="text-muted-foreground px-4 py-3 text-left font-medium">Name</th>
+                      <th class="text-muted-foreground px-3 py-3 text-left font-medium">Role</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Assigned</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">In Progress</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Submit</th>
+                      <th class="text-muted-foreground px-3 py-3 text-right font-medium">Complete</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/saegim-frontend/src/routes/projects/[id]/review/+page.svelte
+++ b/saegim-frontend/src/routes/projects/[id]/review/+page.svelte
@@ -39,9 +39,9 @@
       queue = items
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '데이터를 불러오는 데 실패했습니다.'
+        error = 'Failed to load data.'
       }
     } finally {
       isLoading = false
@@ -53,13 +53,13 @@
     try {
       await reviewPage(pageId, { action: 'approved' })
       queue = queue.filter((item) => item.page_id !== pageId)
-      uiStore.showNotification('승인 완료', 'success')
+      uiStore.showNotification('Approve Complete', 'success')
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
-        uiStore.showNotification('이미 처리된 항목입니다', 'info')
+        uiStore.showNotification('This item has already been processed', 'info')
         queue = queue.filter((item) => item.page_id !== pageId)
       } else {
-        uiStore.showNotification('승인에 실패했습니다', 'error')
+        uiStore.showNotification('Failed to approve', 'error')
       }
     } finally {
       processingId = null
@@ -86,13 +86,13 @@
       queue = queue.filter((item) => item.page_id !== pageId)
       activeRejectId = null
       rejectComment = ''
-      uiStore.showNotification('반려 완료', 'success')
+      uiStore.showNotification('Reject Complete', 'success')
     } catch (e) {
       if (e instanceof ApiError && e.status === 409) {
-        uiStore.showNotification('이미 처리된 항목입니다', 'info')
+        uiStore.showNotification('This item has already been processed', 'info')
         queue = queue.filter((item) => item.page_id !== pageId)
       } else {
-        uiStore.showNotification('반려에 실패했습니다', 'error')
+        uiStore.showNotification('Failed to reject', 'error')
       }
     } finally {
       processingId = null
@@ -124,18 +124,18 @@
           >
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
-          {project?.name ?? '프로젝트'}
+          {project?.name ?? 'Project'}
         </a>
       </div>
 
       <div class="mb-6">
-        <h1 class="text-foreground text-2xl font-bold">검수 큐</h1>
-        <p class="text-muted-foreground mt-1 text-sm">제출된 페이지를 검수합니다</p>
+        <h1 class="text-foreground text-2xl font-bold">Review Queue</h1>
+        <p class="text-muted-foreground mt-1 text-sm">Review submitted pages</p>
       </div>
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="검수 대기 목록 불러오는 중..." />
+          <LoadingSpinner message="Loading review queue..." />
         </div>
       {:else if error}
         <div
@@ -159,7 +159,7 @@
             </svg>
           </div>
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadData}>다시 시도</Button>
+          <Button variant="outline" onclick={loadData}>Retry</Button>
         </div>
       {:else if queue.length === 0}
         <div class="bg-muted border-border rounded-2xl border p-16 text-center">
@@ -180,12 +180,12 @@
               />
             </svg>
           </div>
-          <p class="text-muted-foreground mb-2 text-lg font-medium">검수 대기 항목이 없습니다</p>
-          <p class="text-muted-foreground text-sm">제출된 페이지가 있으면 여기에 표시됩니다.</p>
+          <p class="text-muted-foreground mb-2 text-lg font-medium">No pages awaiting review</p>
+          <p class="text-muted-foreground text-sm">Submitted pages will appear here.</p>
         </div>
       {:else}
         <div class="text-muted-foreground mb-4 text-sm">
-          {queue.length}건의 검수 대기 항목
+          {queue.length} review items
         </div>
         <div class="space-y-3">
           {#each queue as item (item.page_id)}
@@ -199,15 +199,15 @@
                         class="text-foreground hover:text-primary font-medium transition-colors"
                       >
                         {item.document_filename}
-                        <span class="font-normal">— 페이지 {item.page_no}</span>
+                        <span class="font-normal">— Page {item.page_no}</span>
                       </a>
                     </div>
                     <div class="text-muted-foreground mt-1.5 flex items-center gap-3 text-sm">
                       {#if item.assigned_to_name}
-                        <span>작업자: {item.assigned_to_name}</span>
+                        <span>Annotator: {item.assigned_to_name}</span>
                         <span>·</span>
                       {/if}
-                      <span>제출: {formatDate(item.submitted_at)}</span>
+                      <span>Submit: {formatDate(item.submitted_at)}</span>
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
@@ -217,7 +217,7 @@
                       disabled={processingId === item.page_id}
                       onclick={() => startReject(item.page_id)}
                     >
-                      반려
+                      Reject
                     </Button>
                     <Button
                       variant="default"
@@ -225,7 +225,7 @@
                       disabled={processingId === item.page_id}
                       onclick={() => handleApprove(item.page_id)}
                     >
-                      {processingId === item.page_id ? '처리 중...' : '승인'}
+                      {processingId === item.page_id ? 'Processing...' : 'Approve'}
                     </Button>
                   </div>
                 </div>
@@ -237,25 +237,25 @@
                     class="text-foreground mb-1.5 block text-sm font-medium"
                     for="reject-comment-{item.page_id}"
                   >
-                    반려 사유 (선택)
+                    Rejection Reason (Optional)
                   </label>
                   <textarea
                     id="reject-comment-{item.page_id}"
                     class="border-border focus:border-ring focus:ring-ring/20 bg-background text-foreground mb-3 block w-full resize-none rounded-lg border px-3 py-2.5 text-sm transition-all outline-none focus:ring-2"
                     bind:value={rejectComment}
-                    placeholder="반려 사유를 입력하세요"
+                    placeholder="Enter a rejection reason"
                     rows="2"
                     maxlength={2000}
                   ></textarea>
                   <div class="flex justify-end gap-2">
-                    <Button variant="outline" size="sm" onclick={cancelReject}>취소</Button>
+                    <Button variant="outline" size="sm" onclick={cancelReject}>Cancel</Button>
                     <Button
                       variant="destructive"
                       size="sm"
                       disabled={processingId === item.page_id}
                       onclick={() => confirmReject(item.page_id)}
                     >
-                      {processingId === item.page_id ? '처리 중...' : '반려 확인'}
+                      {processingId === item.page_id ? 'Processing...' : 'Confirm Rejection'}
                     </Button>
                   </div>
                 </div>

--- a/saegim-frontend/src/routes/projects/[id]/settings/+page.svelte
+++ b/saegim-frontend/src/routes/projects/[id]/settings/+page.svelte
@@ -79,9 +79,9 @@
       }
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '설정을 불러오는 데 실패했습니다.'
+        error = 'Failed to load settings.'
       }
     } finally {
       isLoading = false
@@ -101,9 +101,9 @@
     error = null
     try {
       ocrConfig = await addEngine(id, data)
-      showSuccess('엔진이 추가되었습니다.')
+      showSuccess('Engine added.')
     } catch {
-      error = '엔진 추가에 실패했습니다.'
+      error = 'Failed to add engine.'
     }
   }
 
@@ -116,9 +116,9 @@
     error = null
     try {
       ocrConfig = await updateEngine(id, engineId, data)
-      showSuccess('엔진 설정이 저장되었습니다.')
+      showSuccess('Engine settings saved.')
     } catch {
-      error = '엔진 설정 저장에 실패했습니다.'
+      error = 'Failed to save engine settings.'
     }
   }
 
@@ -132,9 +132,9 @@
       const next = { ...connectionStatuses }
       delete next[engineId]
       connectionStatuses = next
-      showSuccess('엔진이 삭제되었습니다.')
+      showSuccess('Engine deleted.')
     } catch {
-      error = '엔진 삭제에 실패했습니다.'
+      error = 'Failed to delete engine.'
     }
   }
 
@@ -145,7 +145,7 @@
     try {
       ocrConfig = await setDefaultEngine(id, { engine_id: engineId })
     } catch {
-      error = '기본 엔진 설정에 실패했습니다.'
+      error = 'Failed to set default engine.'
     }
   }
 
@@ -159,7 +159,7 @@
     } catch {
       connectionStatuses = {
         ...connectionStatuses,
-        [engineId]: { success: false, message: '연결 테스트에 실패했습니다.' },
+        [engineId]: { success: false, message: 'Connection test failed.' },
       }
     } finally {
       const next = new Set(testingEngines)
@@ -177,9 +177,9 @@
     try {
       const newMember = await addProjectMember(id, { user_id: userId, role })
       members = [...members, newMember]
-      showSuccess('멤버가 추가되었습니다.')
+      showSuccess('Member added.')
     } catch {
-      error = '멤버 추가에 실패했습니다.'
+      error = 'Failed to add member.'
     }
   }
 
@@ -190,9 +190,9 @@
     try {
       const updated = await updateProjectMemberRole(id, userId, { role })
       members = members.map((m) => (m.user_id === userId ? updated : m))
-      showSuccess('역할이 변경되었습니다.')
+      showSuccess('Role updated.')
     } catch {
-      error = '역할 변경에 실패했습니다.'
+      error = 'Failed to update role.'
     }
   }
 
@@ -203,9 +203,9 @@
     try {
       await removeProjectMember(id, userId)
       members = members.filter((m) => m.user_id !== userId)
-      showSuccess('멤버가 제거되었습니다.')
+      showSuccess('Member removed.')
     } catch {
-      error = '멤버 제거에 실패했습니다.'
+      error = 'Failed to remove member.'
     }
   }
 
@@ -236,14 +236,14 @@
             >
               <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
-            문서 목록
+            Document List
           </a>
         {/if}
       </div>
 
       <div class="mb-6 flex items-center justify-between">
         <div>
-          <h1 class="text-foreground text-2xl font-bold">프로젝트 설정</h1>
+          <h1 class="text-foreground text-2xl font-bold">Project Settings</h1>
           {#if project}
             <p class="text-muted-foreground mt-1 text-sm">{project.name}</p>
           {/if}
@@ -252,14 +252,14 @@
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="설정 불러오는 중..." />
+          <LoadingSpinner message="Loading settings..." />
         </div>
       {:else if error}
         <div
           class="bg-destructive/10 dark:bg-destructive/20 border-destructive/30 rounded-xl border p-6 text-center"
         >
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadData}>다시 시도</Button>
+          <Button variant="outline" onclick={loadData}>Retry</Button>
         </div>
       {:else if ocrConfig}
         {#if successMessage}
@@ -273,8 +273,8 @@
 
         <Tabs.Root value="ocr" class="w-full">
           <Tabs.List class="mb-4">
-            <Tabs.Trigger value="ocr">OCR 설정</Tabs.Trigger>
-            <Tabs.Trigger value="members">멤버 관리</Tabs.Trigger>
+            <Tabs.Trigger value="ocr">OCR Settings</Tabs.Trigger>
+            <Tabs.Trigger value="members">Member Admin</Tabs.Trigger>
           </Tabs.List>
 
           <Tabs.Content value="ocr">

--- a/saegim-frontend/src/routes/register/+page.svelte
+++ b/saegim-frontend/src/routes/register/+page.svelte
@@ -18,10 +18,10 @@
   let isSubmitting = $state(false)
   let loginIdStatus = $state<'idle' | 'invalid' | 'checking' | 'available' | 'taken'>('idle')
   let loginIdHint = $derived.by(() => {
-    if (loginIdStatus === 'invalid') return 'ID는 3자 이상이어야 합니다.'
-    if (loginIdStatus === 'checking') return 'ID 중복 확인 중입니다...'
-    if (loginIdStatus === 'available') return '사용 가능한 ID입니다.'
-    if (loginIdStatus === 'taken') return '이미 사용 중인 ID입니다.'
+    if (loginIdStatus === 'invalid') return 'ID must be at least 3 characters.'
+    if (loginIdStatus === 'checking') return 'Checking ID availability...'
+    if (loginIdStatus === 'available') return 'ID is available.'
+    if (loginIdStatus === 'taken') return 'ID is already in use.'
     return null
   })
 
@@ -67,17 +67,17 @@
     if (!trimmedLoginId || !password || !trimmedName || !trimmedEmail) return
 
     if (password !== passwordConfirm) {
-      error = '비밀번호가 일치하지 않습니다.'
+      error = 'Passwords do not match.'
       return
     }
 
     if (password.length < 8) {
-      error = '비밀번호는 최소 8자 이상이어야 합니다.'
+      error = 'Password must be at least 8 characters.'
       return
     }
 
     if (trimmedLoginId.length < 3) {
-      error = 'ID는 3자 이상이어야 합니다.'
+      error = 'ID must be at least 3 characters.'
       return
     }
 
@@ -91,7 +91,7 @@
         loginIdStatus = isAvailable ? 'available' : 'taken'
       }
       if (!isAvailable) {
-        error = '이미 사용 중인 ID입니다.'
+        error = 'ID is already in use.'
         return
       }
 
@@ -105,9 +105,9 @@
       await goto('/')
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
-        error = '이미 사용 중인 ID 또는 이메일입니다.'
+        error = 'ID or email is already in use.'
       } else {
-        error = '회원가입 중 오류가 발생했습니다. 다시 시도해 주세요.'
+        error = 'An error occurred while signing up. Please try again.'
       }
     } finally {
       isSubmitting = false
@@ -122,7 +122,7 @@
     <Card.Root class="w-full max-w-sm">
       <Card.Header class="text-center">
         <Card.Title class="text-2xl font-bold">saegim</Card.Title>
-        <Card.Description>새 계정을 만드세요</Card.Description>
+        <Card.Description>Create a new account</Card.Description>
       </Card.Header>
       <Card.Content>
         <form onsubmit={handleSubmit} class="space-y-4">
@@ -139,7 +139,7 @@
             <Input
               id="login-id"
               type="text"
-              placeholder="사용할 ID"
+              placeholder="Choose an ID"
               bind:value={loginId}
               required
               autocomplete="username"
@@ -158,11 +158,11 @@
           </div>
 
           <div class="space-y-2">
-            <Label for="password">비밀번호</Label>
+            <Label for="password">Password</Label>
             <Input
               id="password"
               type="password"
-              placeholder="최소 8자"
+              placeholder="At least 8 characters"
               bind:value={password}
               required
               minlength={8}
@@ -171,7 +171,7 @@
           </div>
 
           <div class="space-y-2">
-            <Label for="password-confirm">비밀번호 확인</Label>
+            <Label for="password-confirm">Confirm Password</Label>
             <Input
               id="password-confirm"
               type="password"
@@ -183,11 +183,11 @@
           </div>
 
           <div class="space-y-2">
-            <Label for="name">이름</Label>
+            <Label for="name">Name</Label>
             <Input
               id="name"
               type="text"
-              placeholder="홍길동"
+              placeholder="Jane Doe"
               bind:value={name}
               required
               autocomplete="name"
@@ -195,7 +195,7 @@
           </div>
 
           <div class="space-y-2">
-            <Label for="email">이메일</Label>
+            <Label for="email">Email</Label>
             <Input
               id="email"
               type="email"
@@ -207,14 +207,14 @@
           </div>
 
           <Button type="submit" class="w-full" disabled={isSubmitting}>
-            {isSubmitting ? '가입 중...' : '회원가입'}
+            {isSubmitting ? 'Signing up...' : 'Sign up'}
           </Button>
         </form>
       </Card.Content>
       <Card.Footer class="justify-center">
         <p class="text-muted-foreground text-sm">
-          이미 계정이 있으신가요?
-          <a href="/login" class="text-primary font-medium hover:underline">로그인</a>
+          Already have an account?
+          <a href="/login" class="text-primary font-medium hover:underline">Sign in</a>
         </p>
       </Card.Footer>
     </Card.Root>

--- a/saegim-frontend/src/routes/tasks/+page.svelte
+++ b/saegim-frontend/src/routes/tasks/+page.svelte
@@ -34,17 +34,17 @@
   }
 
   const statusLabels: Record<PageStatus, string> = {
-    pending: '대기',
-    in_progress: '진행중',
-    submitted: '제출됨',
-    reviewed: '검토완료',
+    pending: 'Pending',
+    in_progress: 'In Progress',
+    submitted: 'Submitted',
+    reviewed: 'Reviewed',
   }
 
   type FilterKey = 'all' | 'in_progress' | 'submitted'
   const filterOptions: { key: FilterKey; label: string }[] = [
-    { key: 'all', label: '전체' },
-    { key: 'in_progress', label: '진행중' },
-    { key: 'submitted', label: '제출됨' },
+    { key: 'all', label: 'All' },
+    { key: 'in_progress', label: 'In Progress' },
+    { key: 'submitted', label: 'Submitted' },
   ]
 
   function formatDate(dateStr: string): string {
@@ -63,9 +63,9 @@
       tasks = await getMyTasks()
     } catch (e) {
       if (e instanceof NetworkError) {
-        error = '백엔드 서버에 연결할 수 없습니다.'
+        error = 'Cannot connect to the backend server.'
       } else {
-        error = '작업 목록을 불러오는 데 실패했습니다.'
+        error = 'Failed to load tasks.'
       }
     } finally {
       isLoading = false
@@ -83,8 +83,8 @@
   <div class="bg-background flex-1 overflow-y-auto p-8">
     <div class="mx-auto max-w-4xl">
       <div class="mb-6">
-        <h1 class="text-foreground text-2xl font-bold">내 작업</h1>
-        <p class="text-muted-foreground mt-1 text-sm">할당된 레이블링 작업을 관리합니다</p>
+        <h1 class="text-foreground text-2xl font-bold">My Tasks</h1>
+        <p class="text-muted-foreground mt-1 text-sm">Manage assigned labeling tasks</p>
       </div>
 
       {#if !isLoading && !error}
@@ -113,7 +113,7 @@
 
       {#if isLoading}
         <div class="py-12">
-          <LoadingSpinner message="작업 불러오는 중..." />
+          <LoadingSpinner message="Loading tasks..." />
         </div>
       {:else if error}
         <div
@@ -137,7 +137,7 @@
             </svg>
           </div>
           <p class="text-destructive mb-4 font-medium">{error}</p>
-          <Button variant="outline" onclick={loadTasks}>다시 시도</Button>
+          <Button variant="outline" onclick={loadTasks}>Retry</Button>
         </div>
       {:else if tasks.length === 0}
         <div class="bg-muted border-border rounded-2xl border p-16 text-center">
@@ -158,14 +158,14 @@
               />
             </svg>
           </div>
-          <p class="text-muted-foreground mb-2 text-lg font-medium">할당된 작업이 없습니다</p>
+          <p class="text-muted-foreground mb-2 text-lg font-medium">No assigned tasks</p>
           <p class="text-muted-foreground text-sm">
-            프로젝트 관리자가 작업을 할당하면 여기에 표시됩니다.
+            Tasks assigned by a project admin will appear here.
           </p>
         </div>
       {:else if filteredTasks.length === 0}
         <div class="bg-muted border-border rounded-xl border p-8 text-center">
-          <p class="text-muted-foreground text-sm">해당 상태의 작업이 없습니다.</p>
+          <p class="text-muted-foreground text-sm">No tasks with this status.</p>
         </div>
       {:else}
         <div class="space-y-3">
@@ -178,7 +178,7 @@
                       <h3 class="text-foreground font-medium">
                         {task.document_filename}
                         <span class="text-muted-foreground font-normal">
-                          — 페이지 {task.page_no}
+                          — Page {task.page_no}
                         </span>
                       </h3>
                       <span class="badge {statusColors[task.status]}">
@@ -188,7 +188,7 @@
                     <div class="text-muted-foreground mt-1.5 flex items-center gap-3 text-sm">
                       <span>{task.project_name}</span>
                       <span>·</span>
-                      <span>할당: {formatDate(task.assigned_at)}</span>
+                      <span>Assigned: {formatDate(task.assigned_at)}</span>
                     </div>
                   </div>
                   <svg

--- a/saegim-frontend/tests/lib/api/tasks.test.ts
+++ b/saegim-frontend/tests/lib/api/tasks.test.ts
@@ -145,7 +145,7 @@ describe('reviewPage', () => {
     }
     mockFetch.mockResolvedValueOnce(jsonResponse(200, pageResponse))
 
-    const result = await reviewPage('p1', { action: 'rejected', comment: '수정 필요' })
+    const result = await reviewPage('p1', { action: 'rejected', comment: 'Needs revision' })
 
     expect(result.status).toBe('in_progress')
   })

--- a/saegim-frontend/tests/lib/components/admin/AdminProjectsPanel.test.ts
+++ b/saegim-frontend/tests/lib/components/admin/AdminProjectsPanel.test.ts
@@ -36,7 +36,7 @@ describe('AdminProjectsPanel', () => {
       props: { projects: [] },
     })
 
-    expect(screen.getByText('등록된 프로젝트가 없습니다.')).toBeTruthy()
+    expect(screen.getByText('No projects registered.')).toBeTruthy()
   })
 
   it('renders project list with names', () => {
@@ -62,6 +62,6 @@ describe('AdminProjectsPanel', () => {
       props: { projects: sampleProjects },
     })
 
-    expect(screen.getByText('프로젝트 관리')).toBeTruthy()
+    expect(screen.getByText('Project Admin')).toBeTruthy()
   })
 })

--- a/saegim-frontend/tests/lib/components/admin/AdminStatsPanel.test.ts
+++ b/saegim-frontend/tests/lib/components/admin/AdminStatsPanel.test.ts
@@ -23,9 +23,9 @@ describe('AdminStatsPanel', () => {
       props: { stats: sampleStats },
     })
 
-    expect(screen.getByText('총 사용자')).toBeTruthy()
-    expect(screen.getByText('총 프로젝트')).toBeTruthy()
-    expect(screen.getByText('전체 완료율')).toBeTruthy()
+    expect(screen.getByText('Total Users')).toBeTruthy()
+    expect(screen.getByText('Total Projects')).toBeTruthy()
+    expect(screen.getByText('Overall Completion')).toBeTruthy()
   })
 
   it('shows correct values', () => {
@@ -43,7 +43,7 @@ describe('AdminStatsPanel', () => {
       props: { stats: sampleStats },
     })
 
-    expect(screen.getByText('활성 사용자: 8명')).toBeTruthy()
+    expect(screen.getByText('Active users: 8')).toBeTruthy()
   })
 
   it('shows zero values gracefully', () => {
@@ -61,6 +61,6 @@ describe('AdminStatsPanel', () => {
     })
 
     expect(screen.getByText('0%')).toBeTruthy()
-    expect(screen.getByText('활성 사용자: 0명')).toBeTruthy()
+    expect(screen.getByText('Active users: 0')).toBeTruthy()
   })
 })

--- a/saegim-frontend/tests/lib/components/admin/AdminUsersPanel.test.ts
+++ b/saegim-frontend/tests/lib/components/admin/AdminUsersPanel.test.ts
@@ -36,7 +36,7 @@ describe('AdminUsersPanel', () => {
       props: { users: [] },
     })
 
-    expect(screen.getByText('등록된 사용자가 없습니다.')).toBeTruthy()
+    expect(screen.getByText('No users registered.')).toBeTruthy()
   })
 
   it('renders user list with names and emails', () => {
@@ -44,7 +44,7 @@ describe('AdminUsersPanel', () => {
       props: { users: sampleUsers },
     })
 
-    expect(screen.getByText('Admin')).toBeTruthy()
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0)
     expect(screen.getByText('admin@example.com')).toBeTruthy()
     expect(screen.getByText('User')).toBeTruthy()
     expect(screen.getByText('user@example.com')).toBeTruthy()
@@ -64,6 +64,6 @@ describe('AdminUsersPanel', () => {
       props: { users: sampleUsers },
     })
 
-    expect(screen.getByText('사용자 관리')).toBeTruthy()
+    expect(screen.getByText('User Admin')).toBeTruthy()
   })
 })

--- a/saegim-frontend/tests/lib/components/canvas/TextOverlay.test.ts
+++ b/saegim-frontend/tests/lib/components/canvas/TextOverlay.test.ts
@@ -35,7 +35,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 0,
           anno_id: 0,
-          text: '안녕하세요 테스트',
+          text: 'Hello test',
         },
         {
           category_type: 'title',
@@ -43,7 +43,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 1,
           anno_id: 1,
-          text: '제목입니다',
+          text: 'This is a title',
         },
       ]),
     )
@@ -51,8 +51,8 @@ describe('TextOverlay', () => {
     render(TextOverlay, { props: { pointerEvents: 'auto' } })
 
     // Both text blocks should be rendered
-    expect(screen.getByText('안녕하세요 테스트')).toBeTruthy()
-    expect(screen.getByText('제목입니다')).toBeTruthy()
+    expect(screen.getByText('Hello test')).toBeTruthy()
+    expect(screen.getByText('This is a title')).toBeTruthy()
   })
 
   it('excludes image-block categories (figure, table, equation_isolated)', () => {
@@ -65,7 +65,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 0,
           anno_id: 0,
-          text: '표시될 텍스트',
+          text: 'Visible text',
         },
         {
           category_type: 'figure',
@@ -73,7 +73,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 1,
           anno_id: 1,
-          text: '숨겨질 그림',
+          text: 'Hidden figure',
         },
         {
           category_type: 'table',
@@ -81,16 +81,16 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 2,
           anno_id: 2,
-          text: '숨겨질 테이블',
+          text: 'Hidden table',
         },
       ]),
     )
 
     render(TextOverlay, { props: { pointerEvents: 'auto' } })
 
-    expect(screen.getByText('표시될 텍스트')).toBeTruthy()
-    expect(screen.queryByText('숨겨질 그림')).toBeNull()
-    expect(screen.queryByText('숨겨질 테이블')).toBeNull()
+    expect(screen.getByText('Visible text')).toBeTruthy()
+    expect(screen.queryByText('Hidden figure')).toBeNull()
+    expect(screen.queryByText('Hidden table')).toBeNull()
   })
 
   it('renders empty string when text is undefined', () => {
@@ -125,7 +125,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 0,
           anno_id: 0,
-          text: '텍스트',
+          text: 'Text',
         },
       ]),
     )
@@ -149,14 +149,14 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 0,
           anno_id: 0,
-          text: '위치 테스트',
+          text: 'Position test',
         },
       ]),
     )
 
     render(TextOverlay, { props: { pointerEvents: 'auto' } })
 
-    const textDiv = screen.getByText('위치 테스트')
+    const textDiv = screen.getByText('Position test')
     const style = textDiv.style
     expect(style.left).toBe('100px')
     expect(style.top).toBe('200px')
@@ -228,7 +228,7 @@ describe('TextOverlay', () => {
           ignore: false,
           order: 0,
           anno_id: 0,
-          text: '줌 테스트',
+          text: 'Zoom test',
         },
       ]),
     )

--- a/saegim-frontend/tests/lib/components/panels/ExtractionPreview.test.ts
+++ b/saegim-frontend/tests/lib/components/panels/ExtractionPreview.test.ts
@@ -59,7 +59,7 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.getByText('OCR 추출 진행 중...')).toBeTruthy()
+    expect(screen.getByText('OCR extraction in progress...')).toBeTruthy()
   })
 
   it('shows auto-extracted data summary when data is available', () => {
@@ -75,9 +75,9 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.getByText('자동 추출 결과가 있습니다')).toBeTruthy()
+    expect(screen.getByText('Automatic extraction results available')).toBeTruthy()
     // 4 total elements: 2 text, 2 figure
-    expect(screen.getByText(/총 4개 요소/)).toBeTruthy()
+    expect(screen.getByText(/Text 2, images 2 - total 4 elements/)).toBeTruthy()
   })
 
   it('shows accept and dismiss buttons when data is available', () => {
@@ -93,8 +93,8 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.getByText('수락')).toBeTruthy()
-    expect(screen.getByText('무시')).toBeTruthy()
+    expect(screen.getByText('Accept')).toBeTruthy()
+    expect(screen.getByText('Ignore')).toBeTruthy()
   })
 
   it('hides after dismiss is clicked', async () => {
@@ -110,12 +110,12 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.getByText('수락')).toBeTruthy()
+    expect(screen.getByText('Accept')).toBeTruthy()
 
-    const dismissBtn = screen.getByText('무시')
+    const dismissBtn = screen.getByText('Ignore')
     await fireEvent.click(dismissBtn)
 
-    expect(screen.queryByText('수락')).toBeNull()
+    expect(screen.queryByText('Accept')).toBeNull()
   })
 
   it('shows no-data hint when auto_extracted_data is null and documentStatus is ready', () => {
@@ -130,8 +130,8 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.getByText('자동 추출 결과가 없습니다.')).toBeTruthy()
-    expect(screen.getByText(/OCR 설정/)).toBeTruthy()
+    expect(screen.getByText('No automatic extraction results.')).toBeTruthy()
+    expect(screen.getByText(/OCR Settings/)).toBeTruthy()
   })
 
   it('does not show no-data hint when documentStatus is undefined (still loading)', () => {
@@ -145,7 +145,7 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.queryByText('자동 추출 결과가 없습니다.')).toBeNull()
+    expect(screen.queryByText('No automatic extraction results.')).toBeNull()
   })
 
   it('does not show data summary when annotations already exist', () => {
@@ -164,7 +164,7 @@ describe('ExtractionPreview', () => {
     })
 
     // Since annotationStore has elements, ExtractionPreview should not show
-    expect(screen.queryByText('자동 추출 결과가 있습니다')).toBeNull()
+    expect(screen.queryByText('Automatic extraction results available')).toBeNull()
   })
 
   it('does not show no-data hint when annotations already exist', () => {
@@ -181,6 +181,6 @@ describe('ExtractionPreview', () => {
       },
     })
 
-    expect(screen.queryByText('자동 추출 결과가 없습니다.')).toBeNull()
+    expect(screen.queryByText('No automatic extraction results.')).toBeNull()
   })
 })

--- a/saegim-frontend/tests/lib/components/panels/PageNavigator.test.ts
+++ b/saegim-frontend/tests/lib/components/panels/PageNavigator.test.ts
@@ -18,7 +18,7 @@ function makePages(count: number): PageSummary[] {
 }
 
 async function expandNavigator(container: HTMLElement) {
-  const toggleBtn = container.querySelector('button[title*="페이지 목록"]') as HTMLButtonElement
+  const toggleBtn = container.querySelector('button[title*="Page List"]') as HTMLButtonElement
   if (toggleBtn) {
     await fireEvent.click(toggleBtn)
   }
@@ -128,7 +128,7 @@ describe('PageNavigator', () => {
       props: { pages, currentPageId: 'page-2' },
     })
 
-    const prevButton = container.querySelector('button[title*="이전"]') as HTMLButtonElement
+    const prevButton = container.querySelector('button[title*="Previous"]') as HTMLButtonElement
     expect(prevButton).toBeTruthy()
     expect(prevButton.disabled).toBe(false)
 
@@ -142,7 +142,7 @@ describe('PageNavigator', () => {
       props: { pages, currentPageId: 'page-2' },
     })
 
-    const nextButton = container.querySelector('button[title*="다음"]') as HTMLButtonElement
+    const nextButton = container.querySelector('button[title*="Next"]') as HTMLButtonElement
     expect(nextButton).toBeTruthy()
     expect(nextButton.disabled).toBe(false)
 

--- a/saegim-frontend/tests/lib/components/settings/OcrSettingsPanel.test.ts
+++ b/saegim-frontend/tests/lib/components/settings/OcrSettingsPanel.test.ts
@@ -32,7 +32,7 @@ describe('OcrSettingsPanel', () => {
   it('renders empty state when no engines registered', () => {
     render(OcrSettingsPanel, { props: { config: emptyConfig } })
 
-    expect(screen.getByText('등록된 엔진이 없습니다.')).toBeTruthy()
+    expect(screen.getByText('No engines registered.')).toBeTruthy()
   })
 
   it('renders engine cards when engines exist', () => {
@@ -45,7 +45,7 @@ describe('OcrSettingsPanel', () => {
   it('shows add engine button', () => {
     render(OcrSettingsPanel, { props: { config: emptyConfig } })
 
-    expect(screen.getByText('엔진 추가')).toBeTruthy()
+    expect(screen.getByText('Add Engine')).toBeTruthy()
   })
 
   it('shows pdfminer fallback note', () => {
@@ -57,7 +57,7 @@ describe('OcrSettingsPanel', () => {
   it('shows header with description', () => {
     render(OcrSettingsPanel, { props: { config: emptyConfig } })
 
-    expect(screen.getByText('OCR 엔진 관리')).toBeTruthy()
+    expect(screen.getByText('OCR Engine Management')).toBeTruthy()
   })
 
   const configWithSplitPipeline: OcrConfigResponse = {

--- a/saegim-frontend/tests/lib/components/settings/ProjectMembersPanel.test.ts
+++ b/saegim-frontend/tests/lib/components/settings/ProjectMembersPanel.test.ts
@@ -37,7 +37,7 @@ describe('ProjectMembersPanel', () => {
       props: { members: [], currentUserId: 'user-1' },
     })
 
-    expect(screen.getByText('멤버가 없습니다.')).toBeTruthy()
+    expect(screen.getByText('No members.')).toBeTruthy()
   })
 
   it('renders member list with names and emails', () => {
@@ -63,12 +63,12 @@ describe('ProjectMembersPanel', () => {
     expect(screen.getByText('Reviewer')).toBeTruthy()
   })
 
-  it('shows "(나)" label for current user', () => {
+  it('shows "(You)" label for current user', () => {
     render(ProjectMembersPanel, {
       props: { members: sampleMembers, currentUserId: 'user-1' },
     })
 
-    expect(screen.getByText('(나)')).toBeTruthy()
+    expect(screen.getByText('(You)')).toBeTruthy()
   })
 
   it('shows header with title', () => {
@@ -76,7 +76,7 @@ describe('ProjectMembersPanel', () => {
       props: { members: [], currentUserId: 'user-1' },
     })
 
-    expect(screen.getByText('멤버 관리')).toBeTruthy()
+    expect(screen.getByText('Member Management')).toBeTruthy()
   })
 
   it('shows add member button when owner or admin', () => {
@@ -84,7 +84,7 @@ describe('ProjectMembersPanel', () => {
       props: { members: sampleMembers, currentUserId: 'user-1', isOwnerOrAdmin: true },
     })
 
-    expect(screen.getByText('멤버 추가')).toBeTruthy()
+    expect(screen.getByText('Add Member')).toBeTruthy()
   })
 
   it('hides add member button when not owner or admin', () => {
@@ -92,7 +92,7 @@ describe('ProjectMembersPanel', () => {
       props: { members: sampleMembers, currentUserId: 'user-2', isOwnerOrAdmin: false },
     })
 
-    expect(screen.queryByText('멤버 추가')).toBeNull()
+    expect(screen.queryByText('Add Member')).toBeNull()
   })
 
   it('shows remove button for non-owner members when owner', () => {
@@ -101,7 +101,7 @@ describe('ProjectMembersPanel', () => {
     })
 
     // Should show remove buttons for non-owner, non-self members
-    const removeButtons = screen.getAllByText('제거')
+    const removeButtons = screen.getAllByText('Remove')
     expect(removeButtons.length).toBe(2) // Bob and Charlie
   })
 
@@ -112,7 +112,7 @@ describe('ProjectMembersPanel', () => {
 
     // Owner (Alice) should not have a remove button
     // Bob, Charlie should have remove buttons
-    const removeButtons = screen.getAllByText('제거')
+    const removeButtons = screen.getAllByText('Remove')
     expect(removeButtons.length).toBe(2)
   })
 })

--- a/saegim-frontend/tests/routes/projects/drag-drop-upload.test.ts
+++ b/saegim-frontend/tests/routes/projects/drag-drop-upload.test.ts
@@ -100,7 +100,7 @@ describe('Project page drag-and-drop upload', () => {
 
     dropZone.dispatchEvent(event)
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 파일을 여기에 놓으세요')).toBeTruthy()
+      expect(screen.getByText('Drop PDF files here')).toBeTruthy()
     })
   })
 
@@ -114,12 +114,12 @@ describe('Project page drag-and-drop upload', () => {
     // Enter then leave
     dropZone.dispatchEvent(createDragEvent('dragenter', [pdfFile]))
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 파일을 여기에 놓으세요')).toBeTruthy()
+      expect(screen.getByText('Drop PDF files here')).toBeTruthy()
     })
 
     dropZone.dispatchEvent(createDragEvent('dragleave'))
     await vi.waitFor(() => {
-      expect(screen.queryByText('PDF 파일을 여기에 놓으세요')).toBeNull()
+      expect(screen.queryByText('Drop PDF files here')).toBeNull()
     })
   })
 
@@ -133,7 +133,7 @@ describe('Project page drag-and-drop upload', () => {
     dropZone.dispatchEvent(event)
 
     // Overlay should not appear
-    expect(screen.queryByText('PDF 파일을 여기에 놓으세요')).toBeNull()
+    expect(screen.queryByText('Drop PDF files here')).toBeNull()
   })
 
   it('uploads PDF on drop', async () => {
@@ -163,7 +163,7 @@ describe('Project page drag-and-drop upload', () => {
     dropZone.dispatchEvent(createDragEvent('drop', [imageFile]))
 
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 파일만 업로드할 수 있습니다.')).toBeTruthy()
+      expect(screen.getByText('Only PDF files can be uploaded.')).toBeTruthy()
     })
     expect(mockUploadDocument).not.toHaveBeenCalled()
   })
@@ -198,7 +198,7 @@ describe('Project page drag-and-drop upload', () => {
     dropZone.dispatchEvent(createDragEvent('drop', [pdfFile]))
 
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 업로드에 실패했습니다.')).toBeTruthy()
+      expect(screen.getByText('Failed to upload PDF.')).toBeTruthy()
     })
   })
 
@@ -211,12 +211,12 @@ describe('Project page drag-and-drop upload', () => {
 
     dropZone.dispatchEvent(createDragEvent('dragenter', [pdfFile]))
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 파일을 여기에 놓으세요')).toBeTruthy()
+      expect(screen.getByText('Drop PDF files here')).toBeTruthy()
     })
 
     dropZone.dispatchEvent(createDragEvent('drop', [pdfFile]))
     await vi.waitFor(() => {
-      expect(screen.queryByText('PDF 파일을 여기에 놓으세요')).toBeNull()
+      expect(screen.queryByText('Drop PDF files here')).toBeNull()
     })
   })
 
@@ -236,7 +236,7 @@ describe('Project page drag-and-drop upload', () => {
 
     dropZone.dispatchEvent(createDragEvent('dragenter', [newPdf]))
     await vi.waitFor(() => {
-      expect(screen.getByText('PDF 파일을 여기에 놓으세요')).toBeTruthy()
+      expect(screen.getByText('Drop PDF files here')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION

## Summary

Refs #137.

This PR continues the documentation and UI i18n cleanup after the initial docs/i18n branch landed.

Completed stages:

1. README English defaults
   - Made the root, demo, e2e, frontend, and backend README entry points English by default.
   - Preserved Korean variants as `README.ko.md` where useful.

2. Frontend UI English copy
   - Translated user-facing Korean copy in the Svelte frontend to English.
   - Updated frontend tests to match the English UI text.

3. Documentation navigation i18n
   - Added existing translated documentation pages to the MkDocs navigation.
   - Added English nav label translations for the English documentation build.
   - Replaced strict-build-breaking relative links to files outside `docs/` with GitHub links.

Key decisions:

- Keep Korean README variants available instead of deleting Korean documentation.
- Treat the English docs build as the default external-facing entry point while preserving Korean docs under the i18n site.
- Use MkDocs static-i18n navigation rather than manual language switch links inside the docs landing pages.

## Verification

- `bun run check`
- `bun run test`
- `bun run format:check`
- `uvx --with-requirements docs/requirements.txt mkdocs build --strict`
